### PR TITLE
Forward OP transactions to sequencer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -153,6 +153,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.0.2 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
+	github.com/peterbourgon/ff/v3 v3.4.0 // indirect
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/VictoriaMetrics/fastcache v1.10.0 h1:5hDJnLsKLpnUEToub7ETuRu8RCkb40wo
 github.com/VictoriaMetrics/fastcache v1.10.0/go.mod h1:tjiYeEfYXCqacuvYw/7UoDIeJaNxq6132xHICNP77w8=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/allegro/bigcache v1.2.1 h1:hg1sY1raCwic3Vnsvje6TT7/pnZba83LeFck5NrFKSc=
 github.com/allegro/bigcache v1.2.1/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
@@ -85,6 +87,7 @@ github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811 h1:ytcWPaNPhNoG
 github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811/go.mod h1:Nb5lgvnQ2+oGlE/EyZy4+2/CxRh9KfvCXnag1vtpxVM=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
+github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
 github.com/consensys/bavard v0.1.13/go.mod h1:9ItSMtA/dXMAiL7BG6bqW2m3NdSEObYWoH223nGHukI=
@@ -197,6 +200,7 @@ github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-martini/martini v0.0.0-20170121215854-22fa46961aab/go.mod h1:/P9AEU963A2AYjv4d1V5eVL1CQbEJq6aCNHDDjibzu8=
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
@@ -423,13 +427,16 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
+github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/kataras/golog v0.0.10/go.mod h1:yJ8YKCmyL+nWjERB90Qwn+bdyBZsaQwU3bTVFgkFIp8=
 github.com/kataras/iris/v12 v12.1.8/go.mod h1:LMYy4VlP67TQ3Zgriz8RE2h2kMZV2SgMYbq3UhfoFmE=
@@ -472,6 +479,7 @@ github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4F
 github.com/labstack/echo/v4 v4.5.0/go.mod h1:czIriw4a0C1dFun+ObrXp7ok03xON0N1awStJ6ArI7Y=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
+github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -573,6 +581,7 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
+github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/mr-tron/base58 v1.1.2/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
@@ -601,6 +610,7 @@ github.com/multiformats/go-multistream v0.4.1/go.mod h1:Mz5eykRVAjJWckE2U78c6xqd
 github.com/multiformats/go-varint v0.0.1/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
+github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzEE/Zbp4w=
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
@@ -641,6 +651,8 @@ github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58/go.mod h1:DXv8WO4yhM
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml/v2 v2.0.5 h1:ipoSadvV8oGUjnUbMub59IDPPwfxF694nG/jwbMiyQg=
+github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
+github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7 h1:oYW+YCJ1pachXTQmzR3rNLYGGz4g/UgFcjb28p/viDM=
 github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7/go.mod h1:CRroGNssyjTd/qIG2FyxByd2S8JEAZXBl4qUrZf8GS0=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
@@ -1077,6 +1089,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/op-geth-proxy/README.md
+++ b/op-geth-proxy/README.md
@@ -11,5 +11,5 @@ go run geth-proxy.go -listen-addr "127.0.0.1:9091" -vm-id 2
 ```
 With env vars:
 ```
-SEQUENCER_PROXY_LISTEN_ADDR=127.0.0.1:9095 go run geth-proxy.go 
+OP_GETH_PROXY_LISTEN_ADDR=127.0.0.1:9095 go run geth-proxy.go
 ```

--- a/op-geth-proxy/README.md
+++ b/op-geth-proxy/README.md
@@ -1,0 +1,15 @@
+Simple proxy service that parses payload data from an `eth_sendRawTransacton` RPC request and forwards it to Espresso sequencer.
+
+### Usage
+Default configuration:
+``` bash
+go run get-proxy.go
+```
+With CLI flags:
+```bash
+go run geth-proxy.go -listen-addr "127.0.0.1:9091" -vm-id 2
+```
+With env vars:
+```
+SEQUENCER_PROXY_LISTEN_ADDR=127.0.0.1:9095 go run geth-proxy.go 
+```

--- a/op-geth-proxy/geth-proxy.go
+++ b/op-geth-proxy/geth-proxy.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"io"
@@ -36,11 +37,20 @@ type rpcMessage struct {
 }
 
 func ForwardToSequencer(message rpcMessage) {
+	var hexString string
+	if err := json.Unmarshal(message.Params[0], &hexString); err != nil {
+		panic(err)
+	}
+	var txnBytes, err = hex.DecodeString(hexString[2:])
+	if err != nil {
+		panic(err)
+	}
+
 	// json.RawMessage is a []byte array, which is marshalled
 	// As a base64-encoded string. Our sequencer API expects a JSON array.
-	payload := make([]int, len(message.Params[0]))
+	payload := make([]int, len(txnBytes))
 	for i := range payload {
-		payload[i] = int(message.Params[0][i])
+		payload[i] = int(txnBytes[i])
 	}
 
 	// Construct a transaction and send it to the sequencer

--- a/op-geth-proxy/geth-proxy.go
+++ b/op-geth-proxy/geth-proxy.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+
+	"github.com/peterbourgon/ff/v3"
+)
+
+// Environment variables beginning with this prefix can be used to instantiate command line flags
+const ENV_PREFIX = "SEQUENCER_PROXY"
+
+var (
+	fs            = flag.NewFlagSet("proxy", flag.ContinueOnError)
+	fromAddr      = fs.String("listen-addr", "127.0.0.1:9090", "proxy's listening adress")
+	sequencerAddr = fs.String("seq-addr", "http://127.0.0.1:50000", "address of espresso sequencer")
+	gethAddr      = fs.String("geth-addr", "http://127.0.0.1:8545", "address of the op-geth node")
+	vm_id         = fs.Int("vm-id", 1, "VM ID of the OP rollup instance")
+)
+
+type Transaction struct {
+	Vm      int   `json:"vm"`
+	Payload []int `json:"payload"`
+}
+
+type rpcMessage struct {
+	Params json.RawMessage `json:"params,omitempty"`
+	Method string          `json:"method,omitempty"`
+}
+
+func ForwardToSequencer(message rpcMessage) {
+	// json.RawMessage is a []byte array, which is marshalled
+	// As a base64-encoded string. Our sequencer API expects a JSON array.
+	payload := make([]int, len(message.Params))
+	for i := range payload {
+		payload[i] = int(message.Params[i])
+	}
+
+	// Construct a transaction and send it to the sequencer
+	txn := Transaction{
+		Vm:      *vm_id,
+		Payload: payload,
+	}
+	marshalled, err := json.Marshal(txn)
+	if err != nil {
+		panic(err)
+	}
+	request, err := http.NewRequest("POST", *sequencerAddr, bytes.NewBuffer(marshalled))
+	if err != nil {
+		panic(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		log.Println("Failed to connect to the sequencer: ", err)
+	}
+	if response.StatusCode != 200 {
+		log.Println("Request failed. Here is the response: ", err)
+	}
+}
+
+type baseHandle struct{}
+
+func (h *baseHandle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	toUrl, err := url.Parse(*gethAddr)
+	if err != nil {
+		panic(err)
+	}
+	proxy := httputil.NewSingleHostReverseProxy(toUrl)
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		panic(err)
+	}
+	// Once we've read the body, we need to replace it with another reader because
+	// ReadAll can only be called once: https://blog.flexicondev.com/read-go-http-request-body-multiple-times
+	r.Body = io.NopCloser(bytes.NewBuffer(body))
+
+	var message rpcMessage
+	if err := json.Unmarshal(body, &message); err != nil {
+		panic(err)
+	}
+	// Check for sendRawTransaction
+	log.Println("Message:", message.Method)
+	if message.Method == "eth_sendRawTransaction" {
+		ForwardToSequencer(message)
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func main() {
+	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarPrefix(ENV_PREFIX)); err != nil {
+		panic(err)
+	}
+
+	h := &baseHandle{}
+	http.Handle("/", h)
+
+	log.Println("Starting proxy server on", *fromAddr)
+	server := &http.Server{
+		Addr:    *fromAddr,
+		Handler: h,
+	}
+	log.Fatal(server.ListenAndServe())
+}

--- a/op-geth-proxy/geth-proxy.go
+++ b/op-geth-proxy/geth-proxy.go
@@ -52,7 +52,7 @@ func ForwardToSequencer(message rpcMessage) {
 	if err != nil {
 		panic(err)
 	}
-	request, err := http.NewRequest("POST", *sequencerAddr, bytes.NewBuffer(marshalled))
+	request, err := http.NewRequest("POST", *sequencerAddr+"/submit/submit", bytes.NewBuffer(marshalled))
 	if err != nil {
 		panic(err)
 	}

--- a/op-geth-proxy/geth-proxy.go
+++ b/op-geth-proxy/geth-proxy.go
@@ -39,11 +39,13 @@ type rpcMessage struct {
 func ForwardToSequencer(message rpcMessage) {
 	var hexString string
 	if err := json.Unmarshal(message.Params[0], &hexString); err != nil {
-		panic(err)
+		log.Println("Error decoding params field of the rpc message.")
+		return
 	}
 	var txnBytes, err = hex.DecodeString(hexString[2:])
 	if err != nil {
-		panic(err)
+		log.Println("Error decoding hex string. The first raw transaction parameter must be valid hex.")
+		return
 	}
 
 	// json.RawMessage is a []byte array, which is marshalled
@@ -72,6 +74,7 @@ func ForwardToSequencer(message rpcMessage) {
 	response, err := client.Do(request)
 	if err != nil {
 		log.Println("Failed to connect to the sequencer: ", err)
+		return
 	}
 	if response.StatusCode != 200 {
 		log.Println("Request failed. Here is the response: ", err)
@@ -96,7 +99,8 @@ func (h *baseHandle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var message rpcMessage
 	if err := json.Unmarshal(body, &message); err != nil {
-		panic(err)
+		log.Println("Invalid request: expected RPC message")
+		return
 	}
 	// Check for sendRawTransaction
 	if message.Method == "eth_sendRawTransaction" {

--- a/op-geth-proxy/geth-proxy.go
+++ b/op-geth-proxy/geth-proxy.go
@@ -58,6 +58,7 @@ func ForwardToSequencer(message rpcMessage) {
 	}
 	request.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
+	log.Println("Transaction recieved, forwarding to sequencer.")
 	response, err := client.Do(request)
 	if err != nil {
 		log.Println("Failed to connect to the sequencer: ", err)
@@ -88,7 +89,6 @@ func (h *baseHandle) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 	// Check for sendRawTransaction
-	log.Println("Message:", message.Method)
 	if message.Method == "eth_sendRawTransaction" {
 		ForwardToSequencer(message)
 	}

--- a/op-geth-proxy/geth-proxy.go
+++ b/op-geth-proxy/geth-proxy.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Environment variables beginning with this prefix can be used to instantiate command line flags
-const ENV_PREFIX = "SEQUENCER_PROXY"
+const ENV_PREFIX = "OP_GETH_PROXY"
 
 var (
 	fs            = flag.NewFlagSet("proxy", flag.ContinueOnError)
@@ -31,16 +31,16 @@ type Transaction struct {
 }
 
 type rpcMessage struct {
-	Params json.RawMessage `json:"params,omitempty"`
-	Method string          `json:"method,omitempty"`
+	Params []json.RawMessage `json:"params,omitempty"`
+	Method string            `json:"method,omitempty"`
 }
 
 func ForwardToSequencer(message rpcMessage) {
 	// json.RawMessage is a []byte array, which is marshalled
 	// As a base64-encoded string. Our sequencer API expects a JSON array.
-	payload := make([]int, len(message.Params))
+	payload := make([]int, len(message.Params[0]))
 	for i := range payload {
-		payload[i] = int(message.Params[i])
+		payload[i] = int(message.Params[0][i])
 	}
 
 	// Construct a transaction and send it to the sequencer


### PR DESCRIPTION
Simple proxy service that parses payload data from an `eth_sendRawTransacton` RPC request and forwards it to Espresso sequencer.

Note that this will still forward txns to the op-geth mempool (I wanted to keep the RPC API intact completely), but we can prevent mempool bloat by adjusting TRANSACTION POOL settings here: https://geth.ethereum.org/docs/fundamentals/command-line-options. 

Closes #1 