### PR TITLE
flake: go 1.19 -> 1.20

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
 
   outputs = { self, flake-utils, nixpkgs, nixpkgs-geth, foundry, ... }:
     let
-      goVersion = 19; # Change this to update the whole stack
+      goVersion = 20; # Change this to update the whole stack
       overlays = [
         (final: prev: {
           go = prev."go_1_${toString goVersion}";


### PR DESCRIPTION
This matches the version in the
`us-docker.pkg.dev/oplabs-tools-artifacts/images/ci-builder` image and is required to to have `errors.Join`.