### PR TITLE
Pass useEspresso flag down to batch validation logic

### DIFF
--- a/op-node/rollup/derive/attributes.go
+++ b/op-node/rollup/derive/attributes.go
@@ -54,7 +54,7 @@ func NewFetchingAttributesBuilder(cfg *rollup.Config, l1 L1ReceiptsFetcher, l2 S
 // to additional constraints). It can also be used by validating nodes in the derivation  pipeline
 // to check whether a batch with a given parent is an Espresso batch, in which case the validators
 // must check the additional constraints against that batch.
-func (ba *FetchingAttributesBuilder) ChildNeedsJustificaction(ctx context.Context, l2Parent eth.L2BlockRef) (bool, error) {
+func (ba *FetchingAttributesBuilder) ChildNeedsJustification(ctx context.Context, l2Parent eth.L2BlockRef) (bool, error) {
 	sysConfig, err := ba.l2.SystemConfigByL2Hash(ctx, l2Parent.Hash)
 	if err != nil {
 		return false, NewTemporaryError(fmt.Errorf("failed to retrieve L2 parent block: %w", err))

--- a/op-node/rollup/derive/attributes_queue.go
+++ b/op-node/rollup/derive/attributes_queue.go
@@ -25,7 +25,7 @@ import (
 
 type AttributesBuilder interface {
 	PreparePayloadAttributes(ctx context.Context, l2Parent eth.L2BlockRef, epoch eth.BlockID, justification *eth.L2BatchJustification) (attrs *eth.PayloadAttributes, err error)
-	ChildNeedsJustificaction(ctx context.Context, l2Parent eth.L2BlockRef) (bool, error)
+	ChildNeedsJustification(ctx context.Context, l2Parent eth.L2BlockRef) (bool, error)
 }
 
 type AttributesQueue struct {
@@ -52,7 +52,7 @@ func (aq *AttributesQueue) Origin() eth.L1BlockRef {
 func (aq *AttributesQueue) NextAttributes(ctx context.Context, l2SafeHead eth.L2BlockRef) (*eth.PayloadAttributes, error) {
 	// Get a batch if we need it
 	if aq.batch == nil {
-		usingEspresso, err := aq.builder.ChildNeedsJustificaction(ctx, l2SafeHead)
+		usingEspresso, err := aq.builder.ChildNeedsJustification(ctx, l2SafeHead)
 		if err != nil {
 			return nil, err
 		}

--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -111,7 +111,7 @@ func TestBatchQueueNewOrigin(t *testing.T) {
 
 	// Prev Origin: 0; Safehead Origin: 2; Internal Origin: 0
 	// Should return no data but keep the same origin
-	data, err := bq.NextBatch(context.Background(), safeHead)
+	data, err := bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, data)
 	require.Equal(t, io.EOF, err)
 	require.Equal(t, []eth.L1BlockRef{l1[0]}, bq.l1Blocks)
@@ -120,7 +120,7 @@ func TestBatchQueueNewOrigin(t *testing.T) {
 	// Prev Origin: 1; Safehead Origin: 2; Internal Origin: 0
 	// Should wipe l1blocks + advance internal origin
 	input.origin = l1[1]
-	data, err = bq.NextBatch(context.Background(), safeHead)
+	data, err = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, data)
 	require.Equal(t, io.EOF, err)
 	require.Empty(t, bq.l1Blocks)
@@ -129,7 +129,7 @@ func TestBatchQueueNewOrigin(t *testing.T) {
 	// Prev Origin: 2; Safehead Origin: 2; Internal Origin: 1
 	// Should add to l1Blocks + advance internal origin
 	input.origin = l1[2]
-	data, err = bq.NextBatch(context.Background(), safeHead)
+	data, err = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, data)
 	require.Equal(t, io.EOF, err)
 	require.Equal(t, []eth.L1BlockRef{l1[2]}, bq.l1Blocks)
@@ -173,7 +173,7 @@ func TestBatchQueueEager(t *testing.T) {
 	input.origin = l1[1]
 
 	for i := 0; i < len(batches); i++ {
-		b, e := bq.NextBatch(context.Background(), safeHead)
+		b, e := bq.NextBatch(context.Background(), safeHead, false)
 		require.ErrorIs(t, e, errors[i])
 		require.Equal(t, batches[i], b)
 
@@ -222,7 +222,7 @@ func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
 
 	// Load continuous batches for epoch 0
 	for i := 0; i < len(batches); i++ {
-		b, e := bq.NextBatch(context.Background(), safeHead)
+		b, e := bq.NextBatch(context.Background(), safeHead, false)
 		require.ErrorIs(t, e, errors[i])
 		require.Equal(t, batches[i], b)
 
@@ -236,20 +236,20 @@ func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
 
 	// Advance to origin 1. No forced batches yet.
 	input.origin = l1[1]
-	b, e := bq.NextBatch(context.Background(), safeHead)
+	b, e := bq.NextBatch(context.Background(), safeHead, false)
 	require.ErrorIs(t, e, io.EOF)
 	require.Nil(t, b)
 
 	// Advance to origin 2. No forced batches yet because we are still on epoch 0
 	// & have batches for epoch 0.
 	input.origin = l1[2]
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.ErrorIs(t, e, io.EOF)
 	require.Nil(t, b)
 
 	// Advance to origin 3. Should generate one empty batch.
 	input.origin = l1[3]
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, e)
 	require.NotNil(t, b)
 	require.Equal(t, safeHead.Time+2, b.Timestamp)
@@ -258,13 +258,13 @@ func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
 	safeHead.Time += 2
 	safeHead.Hash = mockHash(b.Timestamp, 2)
 	safeHead.L1Origin = b.Epoch()
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.ErrorIs(t, e, io.EOF)
 	require.Nil(t, b)
 
 	// Advance to origin 4. Should generate one empty batch.
 	input.origin = l1[4]
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, e)
 	require.NotNil(t, b)
 	require.Equal(t, rollup.Epoch(2), b.EpochNum)
@@ -273,7 +273,7 @@ func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
 	safeHead.Time += 2
 	safeHead.Hash = mockHash(b.Timestamp, 2)
 	safeHead.L1Origin = b.Epoch()
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.ErrorIs(t, e, io.EOF)
 	require.Nil(t, b)
 
@@ -315,7 +315,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
 	for i := 0; i < len(batches); i++ {
-		b, e := bq.NextBatch(context.Background(), safeHead)
+		b, e := bq.NextBatch(context.Background(), safeHead, false)
 		require.ErrorIs(t, e, NotEnoughData)
 		require.Nil(t, b)
 	}
@@ -323,7 +323,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	// advance origin. Underlying stage still has no more batches
 	// This is not enough to auto advance yet
 	input.origin = l1[1]
-	b, e := bq.NextBatch(context.Background(), safeHead)
+	b, e := bq.NextBatch(context.Background(), safeHead, false)
 	require.ErrorIs(t, e, io.EOF)
 	require.Nil(t, b)
 
@@ -331,7 +331,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	input.origin = l1[2]
 
 	// Check for a generated batch at t = 12
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(12))
 	require.Empty(t, b.BatchV1.Transactions)
@@ -341,7 +341,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	safeHead.Hash = mockHash(b.Timestamp, 2)
 
 	// Check for generated batch at t = 14
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(14))
 	require.Empty(t, b.BatchV1.Transactions)
@@ -351,7 +351,7 @@ func TestBatchQueueMissing(t *testing.T) {
 	safeHead.Hash = mockHash(b.Timestamp, 2)
 
 	// Check for the inputted batch at t = 16
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, e)
 	require.Equal(t, b, batches[0])
 	require.Equal(t, rollup.Epoch(0), b.EpochNum)
@@ -365,9 +365,9 @@ func TestBatchQueueMissing(t *testing.T) {
 	// Check for the generated batch at t = 18. This batch advances the epoch
 	// Note: We need one io.EOF returned from the bq that advances the internal L1 Blocks view
 	// before the batch will be auto generated
-	_, e = bq.NextBatch(context.Background(), safeHead)
+	_, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.Equal(t, e, io.EOF)
-	b, e = bq.NextBatch(context.Background(), safeHead)
+	b, e = bq.NextBatch(context.Background(), safeHead, false)
 	require.Nil(t, e)
 	require.Equal(t, b.Timestamp, uint64(18))
 	require.Empty(t, b.BatchV1.Transactions)

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -25,10 +25,15 @@ const (
 	BatchFuture
 )
 
+func CheckBatchEspresso() BatchValidity {
+	// TODO: verify batch constraints
+	return BatchAccept
+}
+
 // CheckBatch checks if the given batch can be applied on top of the given l2SafeHead, given the contextual L1 blocks the batch was included in.
 // The first entry of the l1Blocks should match the origin of the l2SafeHead. One or more consecutive l1Blocks should be provided.
 // In case of only a single L1 block, the decision whether a batch is valid may have to stay undecided.
-func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock) BatchValidity {
+func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, usingEspresso bool) BatchValidity {
 	// add details to the log
 	log = log.New(
 		"batch_timestamp", batch.Batch.Timestamp,
@@ -138,6 +143,9 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 			return BatchDrop
 		}
 	}
-
-	return BatchAccept
+	if usingEspresso {
+		return CheckBatchEspresso()
+	} else {
+		return BatchAccept
+	}
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -27,7 +27,7 @@ const (
 
 func CheckBatchEspresso() BatchValidity {
 	// TODO: verify batch constraints
-	return BatchAccept
+	panic("Unimplemented")
 }
 
 // CheckBatch checks if the given batch can be applied on top of the given l2SafeHead, given the contextual L1 blocks the batch was included in.

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -584,7 +584,7 @@ func TestValidBatch(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch)
+			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, false)
 			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
 		})
 	}

--- a/op-node/rollup/driver/sequencer_test.go
+++ b/op-node/rollup/driver/sequencer_test.go
@@ -137,6 +137,10 @@ func (fn testAttrBuilderFn) PreparePayloadAttributes(ctx context.Context, l2Pare
 	return fn(ctx, l2Parent, epoch, justification)
 }
 
+func (fn testAttrBuilderFn) ChildNeedsJustificaction(ctx context.Context, l2Parent eth.L2BlockRef) (bool, error) {
+	panic("Unimplemented")
+}
+
 var _ derive.AttributesBuilder = (testAttrBuilderFn)(nil)
 
 type testOriginSelectorFn func(ctx context.Context, l2Head eth.L2BlockRef) (eth.L1BlockRef, error)

--- a/op-node/rollup/driver/sequencer_test.go
+++ b/op-node/rollup/driver/sequencer_test.go
@@ -137,7 +137,7 @@ func (fn testAttrBuilderFn) PreparePayloadAttributes(ctx context.Context, l2Pare
 	return fn(ctx, l2Parent, epoch, justification)
 }
 
-func (fn testAttrBuilderFn) ChildNeedsJustificaction(ctx context.Context, l2Parent eth.L2BlockRef) (bool, error) {
+func (fn testAttrBuilderFn) ChildNeedsJustification(ctx context.Context, l2Parent eth.L2BlockRef) (bool, error) {
 	panic("Unimplemented")
 }
 


### PR DESCRIPTION
Use the flag returned by `ChildNeedsJustificaction` to determine whether we need to verify espresso-specific batch constraints.  Add a stub `CheckBatchEspresso` method to sanity check that existing CI passes. 