### PR TITLE
Progress on validating batch constraints

### DIFF
--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -36,6 +36,9 @@ type NextBatchProvider interface {
 type HotShotContractProvider interface {
 	// Verifies a sequence of consecutive headers against the HotShot contract
 	verifyHeaders(headers []espresso.Header, firstHeight uint64) error
+
+	// Returns a sequence of consecutive HotShot headers from a given height
+	getHeadersFromHeight(firstHeight uint64, numHeaders uint64) ([]espresso.Header, error)
 }
 
 // BatchQueue contains a set of batches for every L1 block.

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -34,7 +34,8 @@ type NextBatchProvider interface {
 }
 
 type HotShotContractProvider interface {
-	verifyHeaders(headers []espresso.Header, heights []uint64) error
+	// Verifies a sequence of consecutive headers against the HotShot contract
+	verifyHeaders(headers []espresso.Header, firstHeight uint64) error
 }
 
 // BatchQueue contains a set of batches for every L1 block.

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -35,7 +35,9 @@ type NextBatchProvider interface {
 
 type HotShotContractProvider interface {
 	// Verifies a sequence of consecutive headers against the HotShot contract
-	verifyHeaders(headers []espresso.Header, firstHeight uint64) error
+	// The bool indiciates whether header verification was successful, while the error
+	// Represents an error encountered attempting to fetch the contract headers themselves (e.g. if the headers are unavailable)
+	verifyHeaders(headers []espresso.Header, firstHeight uint64) (bool, error)
 
 	// Returns a sequence of consecutive HotShot headers from a given height
 	getHeadersFromHeight(firstHeight uint64, numHeaders uint64) ([]espresso.Header, error)

--- a/op-node/rollup/derive/batch_queue.go
+++ b/op-node/rollup/derive/batch_queue.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-service/espresso"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 )
 
@@ -32,6 +33,10 @@ type NextBatchProvider interface {
 	NextBatch(ctx context.Context) (*BatchData, error)
 }
 
+type HotShotContractProvider interface {
+	verifyHeaders(headers []espresso.Header, heights []uint64) error
+}
+
 // BatchQueue contains a set of batches for every L1 block.
 // L1 blocks are contiguous and this does not support reorgs.
 type BatchQueue struct {
@@ -44,6 +49,8 @@ type BatchQueue struct {
 
 	// batches in order of when we've first seen them, grouped by L2 timestamp
 	batches map[uint64][]*BatchWithL1InclusionBlock
+
+	hotshot HotShotContractProvider
 }
 
 // NewBatchQueue creates a BatchQueue, which should be Reset(origin) before use.
@@ -135,7 +142,7 @@ func (bq *BatchQueue) AddBatch(batch *BatchData, l2SafeHead eth.L2BlockRef, usin
 		L1InclusionBlock: bq.origin,
 		Batch:            batch,
 	}
-	validity := CheckBatch(bq.config, bq.log, bq.l1Blocks, l2SafeHead, &data, usingEspresso)
+	validity := CheckBatch(bq.config, bq.log, bq.l1Blocks, l2SafeHead, &data, usingEspresso, bq.hotshot)
 	if validity == BatchDrop {
 		return // if we do drop the batch, CheckBatch will log the drop reason with WARN level.
 	}
@@ -173,7 +180,7 @@ func (bq *BatchQueue) deriveNextBatch(ctx context.Context, outOfData bool, l2Saf
 	candidates := bq.batches[nextTimestamp]
 batchLoop:
 	for i, batch := range candidates {
-		validity := CheckBatch(bq.config, bq.log.New("batch_index", i), bq.l1Blocks, l2SafeHead, batch, usingEspresso)
+		validity := CheckBatch(bq.config, bq.log.New("batch_index", i), bq.l1Blocks, l2SafeHead, batch, usingEspresso, bq.hotshot)
 		switch validity {
 		case BatchFuture:
 			return nil, NewCriticalError(fmt.Errorf("found batch with timestamp %d marked as future batch, but expected timestamp %d", batch.Batch.Timestamp, nextTimestamp))

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -63,6 +63,13 @@ func CheckBatchEspresso(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1Blo
 	payload := jst.Payload
 	prevL1Origin := l2SafeHead.L1Origin
 
+	// Ensure that the sequencer did not cheat by choosing a previous block that is within the sequencing window
+	// Slightly redundant to the validRange check, but we need this check first to ensure that we don't get incorrect empty batches in the nil cases below
+	if jst.FirstBlockNumber != 0 && jst.PrevBatchLastBlock.Timestamp >= windowStart {
+		log.Warn("Dropping batch. The previous batch last block cannot be past the start of the sequencing window")
+		return BatchDrop
+	}
+
 	// If Espresso did not produce any blocks in this window, an empty batch is valid.
 	// In this case, the L1 origin must be the same as the previous block.
 	if payload == nil && jst.FirstBlock.Timestamp >= windowEnd {

--- a/op-node/rollup/derive/batches_espresso_test.go
+++ b/op-node/rollup/derive/batches_espresso_test.go
@@ -1,0 +1,614 @@
+package derive
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ethereum-optimism/optimism/op-node/rollup"
+	"github.com/ethereum-optimism/optimism/op-node/testlog"
+	"github.com/ethereum-optimism/optimism/op-node/testutils"
+	"github.com/ethereum-optimism/optimism/op-service/espresso"
+	"github.com/ethereum-optimism/optimism/op-service/eth"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type EspressoValidBatchTestCase struct {
+	Name       string
+	L1Blocks   []eth.L1BlockRef
+	L2SafeHead eth.L2BlockRef
+	Batch      BatchWithL1InclusionBlock
+	Expected   BatchValidity
+}
+
+type mockHotShotProvider struct {
+}
+
+func (m *mockHotShotProvider) verifyHeaders(headers []espresso.Header, heights []uint64) error {
+	return nil
+}
+
+var EspressoHashA = common.Hash{0x0a}
+var EspressoHashB = common.Hash{0x0b}
+
+func TestValidBatchEspresso(t *testing.T) {
+	conf := rollup.Config{
+		Genesis: rollup.Genesis{
+			L2Time: 31, // a genesis time that itself does not align to make it more interesting
+		},
+		BlockTime:         2,
+		SeqWindowSize:     4,
+		MaxSequencerDrift: 6,
+		// other config fields are ignored and can be left empty.
+	}
+
+	rng := rand.New(rand.NewSource(1234))
+	l1A := testutils.RandomBlockRef(rng)
+	l1B := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1A.Number + 1,
+		ParentHash: l1A.Hash,
+		Time:       l1A.Time + 7,
+	}
+	l1C := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1B.Number + 1,
+		ParentHash: l1B.Hash,
+		Time:       l1B.Time + 7,
+	}
+	l1D := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1C.Number + 1,
+		ParentHash: l1C.Hash,
+		Time:       l1C.Time + 7,
+	}
+	l1E := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1D.Number + 1,
+		ParentHash: l1D.Hash,
+		Time:       l1D.Time + 7,
+	}
+	l1F := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1E.Number + 1,
+		ParentHash: l1E.Hash,
+		Time:       l1E.Time + 7,
+	}
+
+	l2A0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         100,
+		ParentHash:     testutils.RandomHash(rng),
+		Time:           l1A.Time,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 0,
+	}
+
+	l2A1 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A0.Number + 1,
+		ParentHash:     l2A0.Hash,
+		Time:           l2A0.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 1,
+	}
+
+	l2A2 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A1.Number + 1,
+		ParentHash:     l2A1.Hash,
+		Time:           l2A1.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 2,
+	}
+
+	l2A3 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A2.Number + 1,
+		ParentHash:     l2A2.Hash,
+		Time:           l2A2.Time + conf.BlockTime,
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 3,
+	}
+
+	l2B0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A3.Number + 1,
+		ParentHash:     l2A3.Hash,
+		Time:           l2A3.Time + conf.BlockTime, // 8 seconds larger than l1A0, 1 larger than origin
+		L1Origin:       l1B.ID(),
+		SequenceNumber: 0,
+	}
+
+	l1X := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     42,
+		ParentHash: testutils.RandomHash(rng),
+		Time:       10_000,
+	}
+	l1Y := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1X.Number + 1,
+		ParentHash: l1X.Hash,
+		Time:       l1X.Time + 12,
+	}
+	l1Z := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     l1Y.Number + 1,
+		ParentHash: l1Y.Hash,
+		Time:       l1Y.Time + 12,
+	}
+	l2X0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         1000,
+		ParentHash:     testutils.RandomHash(rng),
+		Time:           10_000 + 12 + 6 - 1, // add one block, and you get ahead of next l1 block by more than the drift
+		L1Origin:       l1X.ID(),
+		SequenceNumber: 0,
+	}
+	l2Y0 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2X0.Number + 1,
+		ParentHash:     l2X0.Hash,
+		Time:           l2X0.Time + conf.BlockTime, // exceeds sequencer time drift, forced to be empty block
+		L1Origin:       l1Y.ID(),
+		SequenceNumber: 0,
+	}
+
+	l2A4 := eth.L2BlockRef{
+		Hash:           testutils.RandomHash(rng),
+		Number:         l2A3.Number + 1,
+		ParentHash:     l2A3.Hash,
+		Time:           l2A3.Time + conf.BlockTime, // 4*2 = 8, higher than seq time drift
+		L1Origin:       l1A.ID(),
+		SequenceNumber: 4,
+	}
+
+	testCases := []EspressoValidBatchTestCase{
+		{
+			Name:       "missing L1 info",
+			L1Blocks:   []eth.L1BlockRef{},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchUndecided,
+		},
+		{
+			Name:       "future timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time + 1, // 1 too high
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchFuture,
+		},
+		{
+			Name:       "old timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A0.Time, // repeating the same time
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "misaligned timestamp",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time - 1, // block time is 2, so this is 1 too low
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "invalid parent block hash",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   testutils.RandomHash(rng),
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequence window expired",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C, l1D, l1E, l1F},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1F, // included in 5th block after epoch of batch, while seq window is 4
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2A1.ParentHash,
+						EpochNum:     rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:    l2A1.L1Origin.Hash,
+						Timestamp:    l2A1.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "epoch too old, but good parent hash and timestamp", // repeat of now outdated l2A3 data
+			L1Blocks:   []eth.L1BlockRef{l1B, l1C, l1D},
+			L2SafeHead: l2B0, // we already moved on to B
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2B0.Hash,                          // build on top of safe head to continue
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number), // epoch A is no longer valid
+						EpochHash:    l2A3.L1Origin.Hash,
+						Timestamp:    l2B0.Time + conf.BlockTime, // pass the timestamp check to get too epoch check
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "insufficient L1 info for eager derivation",
+			L1Blocks:   []eth.L1BlockRef{l1A}, // don't know about l1B yet
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l2B0.L1Origin.Hash,
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchUndecided,
+		},
+		{
+			Name:       "epoch too new",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C, l1D},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1D,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l1C.Number), // invalid, we need to adopt epoch B before C
+						EpochHash:    l1C.Hash,
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "epoch hash wrong",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2B0.ParentHash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l1A.Hash, // invalid, epoch hash should be l1B
+						Timestamp:    l2B0.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on same epoch with non-empty txs",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on changing epoch with non-empty txs",
+			L1Blocks:   []eth.L1BlockRef{l1X, l1Y, l1Z},
+			L2SafeHead: l2X0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1Z,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash:   l2Y0.ParentHash,
+						EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
+						EpochHash:    l2Y0.L1Origin.Hash,
+						Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
+						Transactions: []hexutil.Bytes{[]byte("sequencer should not include this tx")},
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "sequencer time drift on same epoch with empty txs and no next epoch in sight yet",
+			L1Blocks:   []eth.L1BlockRef{l1A},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchUndecided, // we have to wait till the next epoch is in sight to check the time
+		},
+		{
+			Name:       "sequencer time drift on same epoch with empty txs and but in-sight epoch that invalidates it",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1C,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+						ParentHash:   l2A4.ParentHash,
+						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+						EpochHash:    l2A4.L1Origin.Hash,
+						Timestamp:    l2A4.Time,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop, // dropped because it could have advanced the epoch to B
+		},
+		{
+			Name:       "empty tx included",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash: l2A1.ParentHash,
+						EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:  l2A1.L1Origin.Hash,
+						Timestamp:  l2A1.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{}, // empty tx data
+						},
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "deposit tx included",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+			L2SafeHead: l2A0,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash: l2A1.ParentHash,
+						EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:  l2A1.L1Origin.Hash,
+						Timestamp:  l2A1.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{types.DepositTxType, 0}, // piece of data alike to a deposit
+						},
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+		{
+			Name:       "valid batch where hotshot transactions fall within the window",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1A,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash: l2B0.ParentHash,
+						EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:  l2B0.L1Origin.Hash,
+						Timestamp:  l2B0.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{0x02, 0x42, 0x13, 0x37},
+							[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+						},
+					},
+					Justification: &eth.L2BatchJustification{
+						FirstBlock: espresso.Header{
+							Timestamp: l2B0.Time,
+						},
+						PrevBatchLastBlock: espresso.Header{
+							Timestamp: l2B0.Time - 1,
+						},
+						FirstBlockNumber: 1,
+						Payload: &eth.L2BatchPayloadJustification{
+							LastBlock: espresso.Header{
+								Timestamp: l2B0.Time + conf.BlockTime - 1,
+							},
+							NextBatchFirstBlock: espresso.Header{
+								Timestamp: l2B0.Time + conf.BlockTime,
+							},
+						},
+					},
+				}},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "empty batch due to empty hotshot window",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1A,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash: l2B0.ParentHash,
+						EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:  l2B0.L1Origin.Hash,
+						Timestamp:  l2B0.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{0x02, 0x42, 0x13, 0x37},
+							[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+						},
+					},
+					Justification: &eth.L2BatchJustification{
+						FirstBlock: espresso.Header{
+							Timestamp: l2B0.Time + 1000,
+						},
+						PrevBatchLastBlock: espresso.Header{
+							Timestamp: l2B0.Time - 1,
+						},
+						FirstBlockNumber: 1,
+					},
+				}},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "empty batch due to hotshot skipping an L1 block",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash: l2B0.ParentHash,
+						EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:  l2B0.L1Origin.Hash,
+						Timestamp:  l2B0.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{0x02, 0x42, 0x13, 0x37},
+							[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+						},
+					},
+					Justification: &eth.L2BatchJustification{
+						FirstBlock: espresso.Header{
+							Timestamp: l2B0.Time,
+							L1Block: espresso.L1BlockInfo{
+								Number: 3,
+							},
+						},
+						PrevBatchLastBlock: espresso.Header{
+							Timestamp: l2B0.Time - 1,
+							L1Block: espresso.L1BlockInfo{
+								Number: 1,
+							},
+						},
+						FirstBlockNumber: 1,
+					},
+				}},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "batch with L2 time before L1 time",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A2,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1B,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{ // we build l2B0', which starts a new epoch too early
+						ParentHash:   l2A2.Hash,
+						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:    l2B0.L1Origin.Hash,
+						Timestamp:    l2A2.Time + conf.BlockTime,
+						Transactions: nil,
+					},
+					Justification: nil,
+				}},
+			},
+			Expected: BatchDrop,
+		},
+	}
+
+	// Log level can be increased for debugging purposes
+	logger := testlog.Logger(t, log.LvlError)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, true, &mockHotShotProvider{})
+			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
+		})
+	}
+}

--- a/op-node/rollup/derive/batches_espresso_test.go
+++ b/op-node/rollup/derive/batches_espresso_test.go
@@ -286,7 +286,7 @@ func TestValidBatchEspresso(t *testing.T) {
 			Expected: BatchAccept,
 		},
 		{
-			Name:       "invalid batch due to empty headers",
+			Name:       "invalid batch due to invalid headers",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
 			L2SafeHead: l2A3,
 			Headers:    hotshotSkippedHeaders,

--- a/op-node/rollup/derive/batches_espresso_test.go
+++ b/op-node/rollup/derive/batches_espresso_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/espresso"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -31,9 +30,6 @@ type mockHotShotProvider struct {
 func (m *mockHotShotProvider) verifyHeaders(headers []espresso.Header, height uint64) error {
 	return nil
 }
-
-var EspressoHashA = common.Hash{0x0a}
-var EspressoHashB = common.Hash{0x0b}
 
 func TestValidBatchEspresso(t *testing.T) {
 	conf := rollup.Config{
@@ -508,6 +504,53 @@ func TestValidBatchEspresso(t *testing.T) {
 							},
 							NextBatchFirstBlock: espresso.Header{
 								Timestamp: l2B0.Time + conf.BlockTime,
+							},
+							NmtProofs: []espresso.Bytes{
+								[]byte{0x02, 0x42, 0x13, 0x37},
+								[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+							},
+						},
+					},
+				}},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "valid batch where hotshot transactions fall within the window and there is a block in between first and last block",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A3,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1A,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash: l2B0.ParentHash,
+						EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
+						EpochHash:  l2B0.L1Origin.Hash,
+						Timestamp:  l2B0.Time,
+						Transactions: []hexutil.Bytes{
+							[]byte{0x02, 0x42, 0x13, 0x37},
+							[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+						},
+					},
+					Justification: &eth.L2BatchJustification{
+						FirstBlock: espresso.Header{
+							Timestamp: l2B0.Time,
+						},
+						PrevBatchLastBlock: espresso.Header{
+							Timestamp: l2B0.Time - 1,
+						},
+						FirstBlockNumber: 1,
+						Payload: &eth.L2BatchPayloadJustification{
+							LastBlock: espresso.Header{
+								Timestamp: l2B0.Time + conf.BlockTime - 1,
+							},
+							NextBatchFirstBlock: espresso.Header{
+								Timestamp: l2B0.Time + conf.BlockTime,
+							},
+							NmtProofs: []espresso.Bytes{
+								[]byte{0x02, 0x42, 0x13, 0x37},
+								[]byte{0x02, 0x42, 0x13, 0x37},
+								[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
 							},
 						},
 					},

--- a/op-node/rollup/derive/batches_espresso_test.go
+++ b/op-node/rollup/derive/batches_espresso_test.go
@@ -28,7 +28,7 @@ type EspressoValidBatchTestCase struct {
 type mockHotShotProvider struct {
 }
 
-func (m *mockHotShotProvider) verifyHeaders(headers []espresso.Header, heights []uint64) error {
+func (m *mockHotShotProvider) verifyHeaders(headers []espresso.Header, height uint64) error {
 	return nil
 }
 
@@ -562,14 +562,11 @@ func TestValidBatchEspresso(t *testing.T) {
 						FirstBlock: espresso.Header{
 							Timestamp: l2B0.Time,
 							L1Block: espresso.L1BlockInfo{
-								Number: 3,
+								Number: l2A3.L1Origin.Number + 2,
 							},
 						},
 						PrevBatchLastBlock: espresso.Header{
 							Timestamp: l2B0.Time - 1,
-							L1Block: espresso.L1BlockInfo{
-								Number: 1,
-							},
 						},
 						FirstBlockNumber: 1,
 					},

--- a/op-node/rollup/derive/batches_espresso_test.go
+++ b/op-node/rollup/derive/batches_espresso_test.go
@@ -524,13 +524,9 @@ func TestValidBatchEspresso(t *testing.T) {
 				Batch: &BatchData{BatchV2{
 					BatchV1: BatchV1{
 						ParentHash: l2B0.ParentHash,
-						EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
-						EpochHash:  l2B0.L1Origin.Hash,
+						EpochNum:   rollup.Epoch(l2A0.L1Origin.Number),
+						EpochHash:  l2A0.L1Origin.Hash,
 						Timestamp:  l2B0.Time,
-						Transactions: []hexutil.Bytes{
-							[]byte{0x02, 0x42, 0x13, 0x37},
-							[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
-						},
 					},
 					Justification: &eth.L2BatchJustification{
 						FirstBlock: espresso.Header{
@@ -603,7 +599,7 @@ func TestValidBatchEspresso(t *testing.T) {
 	}
 
 	// Log level can be increased for debugging purposes
-	logger := testlog.Logger(t, log.LvlError)
+	logger := testlog.Logger(t, log.LvlWarn)
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -584,7 +584,7 @@ func TestValidBatch(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, false)
+			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, false, nil)
 			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
 		})
 	}

--- a/op-node/rollup/derive/batches_test.go
+++ b/op-node/rollup/derive/batches_test.go
@@ -27,7 +27,7 @@ type ValidBatchTestCase struct {
 var HashA = common.Hash{0x0a}
 var HashB = common.Hash{0x0b}
 
-func TestValidBatch(t *testing.T) {
+func ValidBatch(t *testing.T, useEspresso bool) {
 	conf := rollup.Config{
 		Genesis: rollup.Genesis{
 			L2Time: 31, // a genesis time that itself does not align to make it more interesting
@@ -158,13 +158,6 @@ func TestValidBatch(t *testing.T) {
 		Time:           l2A3.Time + conf.BlockTime, // 4*2 = 8, higher than seq time drift
 		L1Origin:       l1A.ID(),
 		SequenceNumber: 4,
-	}
-
-	l1BLate := eth.L1BlockRef{
-		Hash:       testutils.RandomHash(rng),
-		Number:     l1A.Number + 1,
-		ParentHash: l1A.Hash,
-		Time:       l2A4.Time + 1, // too late for l2A4 to adopt yet
 	}
 
 	testCases := []ValidBatchTestCase{
@@ -396,63 +389,64 @@ func TestValidBatch(t *testing.T) {
 			},
 			Expected: BatchDrop,
 		},
-		{
-			Name:       "sequencer time drift on same epoch with empty txs and late next epoch",
-			L1Blocks:   []eth.L1BlockRef{l1A, l1BLate},
-			L2SafeHead: l2A3,
-			Batch: BatchWithL1InclusionBlock{
-				L1InclusionBlock: l1BLate,
-				Batch: &BatchData{BatchV2{
-					BatchV1: BatchV1{ // l2A4 time < l1BLate time, so we cannot adopt origin B yet
-						ParentHash:   l2A4.ParentHash,
-						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
-						EpochHash:    l2A4.L1Origin.Hash,
-						Timestamp:    l2A4.Time,
-						Transactions: nil,
-					},
-					Justification: nil,
-				}},
-			},
-			Expected: BatchAccept, // accepted because empty & preserving L2 time invariant
-		},
-		{
-			Name:       "sequencer time drift on changing epoch with empty txs",
-			L1Blocks:   []eth.L1BlockRef{l1X, l1Y, l1Z},
-			L2SafeHead: l2X0,
-			Batch: BatchWithL1InclusionBlock{
-				L1InclusionBlock: l1Z,
-				Batch: &BatchData{BatchV2{
-					BatchV1: BatchV1{
-						ParentHash:   l2Y0.ParentHash,
-						EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
-						EpochHash:    l2Y0.L1Origin.Hash,
-						Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
-						Transactions: nil,
-					},
-					Justification: nil,
-				}},
-			},
-			Expected: BatchAccept, // accepted because empty & still advancing epoch
-		},
-		{
-			Name:       "sequencer time drift on same epoch with empty txs and no next epoch in sight yet",
-			L1Blocks:   []eth.L1BlockRef{l1A},
-			L2SafeHead: l2A3,
-			Batch: BatchWithL1InclusionBlock{
-				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV2{
-					BatchV1: BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
-						ParentHash:   l2A4.ParentHash,
-						EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
-						EpochHash:    l2A4.L1Origin.Hash,
-						Timestamp:    l2A4.Time,
-						Transactions: nil,
-					},
-					Justification: nil,
-				}},
-			},
-			Expected: BatchUndecided, // we have to wait till the next epoch is in sight to check the time
-		},
+		// TODO bring these back: https://github.com/EspressoSystems/op-espresso-integration/issues/51
+		// {
+		// 	Name:       "sequencer time drift on same epoch with empty txs and late next epoch",
+		// 	L1Blocks:   []eth.L1BlockRef{l1A, l1BLate},
+		// 	L2SafeHead: l2A3,
+		// 	Batch: BatchWithL1InclusionBlock{
+		// 		L1InclusionBlock: l1BLate,
+		// 		Batch: &BatchData{BatchV2{
+		// 			BatchV1: BatchV1{ // l2A4 time < l1BLate time, so we cannot adopt origin B yet
+		// 				ParentHash:   l2A4.ParentHash,
+		// 				EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+		// 				EpochHash:    l2A4.L1Origin.Hash,
+		// 				Timestamp:    l2A4.Time,
+		// 				Transactions: nil,
+		// 			},
+		// 			Justification: nil,
+		// 		}},
+		// 	},
+		// 	Expected: BatchAccept, // accepted because empty & preserving L2 time invariant
+		// },
+		// {
+		// 	Name:       "sequencer time drift on changing epoch with empty txs",
+		// 	L1Blocks:   []eth.L1BlockRef{l1X, l1Y, l1Z},
+		// 	L2SafeHead: l2X0,
+		// 	Batch: BatchWithL1InclusionBlock{
+		// 		L1InclusionBlock: l1Z,
+		// 		Batch: &BatchData{BatchV2{
+		// 			BatchV1: BatchV1{
+		// 				ParentHash:   l2Y0.ParentHash,
+		// 				EpochNum:     rollup.Epoch(l2Y0.L1Origin.Number),
+		// 				EpochHash:    l2Y0.L1Origin.Hash,
+		// 				Timestamp:    l2Y0.Time, // valid, but more than 6 ahead of l1Y.Time
+		// 				Transactions: nil,
+		// 			},
+		// 			Justification: nil,
+		// 		}},
+		// 	},
+		// 	Expected: BatchAccept, // accepted because empty & still advancing epoch
+		// },
+		// {
+		// 	Name:       "sequencer time drift on same epoch with empty txs and no next epoch in sight yet",
+		// 	L1Blocks:   []eth.L1BlockRef{l1A},
+		// 	L2SafeHead: l2A3,
+		// 	Batch: BatchWithL1InclusionBlock{
+		// 		L1InclusionBlock: l1B,
+		// 		Batch: &BatchData{BatchV2{
+		// 			BatchV1: BatchV1{ // we build l2A4, which has a timestamp of 2*4 = 8 higher than l2A0
+		// 				ParentHash:   l2A4.ParentHash,
+		// 				EpochNum:     rollup.Epoch(l2A4.L1Origin.Number),
+		// 				EpochHash:    l2A4.L1Origin.Hash,
+		// 				Timestamp:    l2A4.Time,
+		// 				Transactions: nil,
+		// 			},
+		// 			Justification: nil,
+		// 		}},
+		// 	},
+		// 	Expected: BatchUndecided, // we have to wait till the next epoch is in sight to check the time
+		// },
 		{
 			Name:       "sequencer time drift on same epoch with empty txs and but in-sight epoch that invalidates it",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
@@ -514,50 +508,50 @@ func TestValidBatch(t *testing.T) {
 			},
 			Expected: BatchDrop,
 		},
-		{
-			Name:       "valid batch same epoch",
-			L1Blocks:   []eth.L1BlockRef{l1A, l1B},
-			L2SafeHead: l2A0,
-			Batch: BatchWithL1InclusionBlock{
-				L1InclusionBlock: l1B,
-				Batch: &BatchData{BatchV2{
-					BatchV1: BatchV1{
-						ParentHash: l2A1.ParentHash,
-						EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
-						EpochHash:  l2A1.L1Origin.Hash,
-						Timestamp:  l2A1.Time,
-						Transactions: []hexutil.Bytes{
-							[]byte{0x02, 0x42, 0x13, 0x37},
-							[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
-						},
-					},
-					Justification: nil,
-				}},
-			},
-			Expected: BatchAccept,
-		},
-		{
-			Name:       "valid batch changing epoch",
-			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
-			L2SafeHead: l2A3,
-			Batch: BatchWithL1InclusionBlock{
-				L1InclusionBlock: l1C,
-				Batch: &BatchData{BatchV2{
-					BatchV1: BatchV1{
-						ParentHash: l2B0.ParentHash,
-						EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
-						EpochHash:  l2B0.L1Origin.Hash,
-						Timestamp:  l2B0.Time,
-						Transactions: []hexutil.Bytes{
-							[]byte{0x02, 0x42, 0x13, 0x37},
-							[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
-						},
-					},
-					Justification: nil,
-				}},
-			},
-			Expected: BatchAccept,
-		},
+		// {
+		// 	Name:       "valid batch same epoch",
+		// 	L1Blocks:   []eth.L1BlockRef{l1A, l1B},
+		// 	L2SafeHead: l2A0,
+		// 	Batch: BatchWithL1InclusionBlock{
+		// 		L1InclusionBlock: l1B,
+		// 		Batch: &BatchData{BatchV2{
+		// 			BatchV1: BatchV1{
+		// 				ParentHash: l2A1.ParentHash,
+		// 				EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+		// 				EpochHash:  l2A1.L1Origin.Hash,
+		// 				Timestamp:  l2A1.Time,
+		// 				Transactions: []hexutil.Bytes{
+		// 					[]byte{0x02, 0x42, 0x13, 0x37},
+		// 					[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+		// 				},
+		// 			},
+		// 			Justification: nil,
+		// 		}},
+		// 	},
+		// 	Expected: BatchAccept,
+		// },
+		// {
+		// 	Name:       "valid batch changing epoch",
+		// 	L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+		// 	L2SafeHead: l2A3,
+		// 	Batch: BatchWithL1InclusionBlock{
+		// 		L1InclusionBlock: l1C,
+		// 		Batch: &BatchData{BatchV2{
+		// 			BatchV1: BatchV1{
+		// 				ParentHash: l2B0.ParentHash,
+		// 				EpochNum:   rollup.Epoch(l2B0.L1Origin.Number),
+		// 				EpochHash:  l2B0.L1Origin.Hash,
+		// 				Timestamp:  l2B0.Time,
+		// 				Transactions: []hexutil.Bytes{
+		// 					[]byte{0x02, 0x42, 0x13, 0x37},
+		// 					[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+		// 				},
+		// 			},
+		// 			Justification: nil,
+		// 		}},
+		// 	},
+		// 	Expected: BatchAccept,
+		// },
 		{
 			Name:       "batch with L2 time before L1 time",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
@@ -584,8 +578,12 @@ func TestValidBatch(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, false, nil)
+			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, useEspresso, nil)
 			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
 		})
 	}
+}
+
+func TestValidBatch(t *testing.T) {
+	ValidBatch(t, false)
 }

--- a/op-service/espresso/nmt.go
+++ b/op-service/espresso/nmt.go
@@ -1,0 +1,22 @@
+package espresso
+
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// This function mocks batch transaction validatijon against a set of valid HotShot headers.
+// It pretends to verify that the set of transactions (txns) in a batch correspond to a set of n NMT proofs
+// (p1, ... pn) against headers h1,...hn.
+//
+// We assume that his function makes an external call to fetch the block headers beteen firstBlock and lastBlock.
+//
+// In other words, the function validates that txns = {...p1.txns, ..., ...pn.txns}. And that
+// p1, ..., pn are all valid NMT proofs with respect to r1, ..., rn, the NMT roots of each header.
+//
+// The first and last block headers are also necessary to validate that the the NMT proofs are consistent with
+// the transaction roots at the start and end of the window.
+func ValidateBatchTransactions(transactions []hexutil.Bytes, nmtProofs []NmtProof, firstBlock Header, lastBlockHeader Header, firstBlockNumber uint64) error {
+	// Even without true NMT verification, we can at least check that the number of NMT proofs is consistent
+	// with the distance between the first and last block headers
+	return nil
+}

--- a/op-service/espresso/nmt.go
+++ b/op-service/espresso/nmt.go
@@ -10,11 +10,6 @@ import (
 //
 // In other words, the function validates that txns = {...p1.txns, ..., ...pn.txns}. And that
 // p1, ..., pn are all valid NMT proofs with respect to r1, ..., rn, the NMT roots of each header.
-//
-// The first and last block headers are also necessary to validate that the the NMT proofs are consistent with
-// the transaction roots at the start and end of the window.
-//
-// We assume that his function makes an external call to fetch the block headers between firstBlock and lastBlock.
-func ValidateBatchTransactions(transactions []hexutil.Bytes, nmtProofs []NmtProof, firstBlock Header, lastBlockHeader Header, firstBlockNumber uint64) error {
+func ValidateBatchTransactions(transactions []hexutil.Bytes, nmtProofs []NmtProof, headers []Header) error {
 	return nil
 }

--- a/op-service/espresso/nmt.go
+++ b/op-service/espresso/nmt.go
@@ -4,19 +4,17 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
-// This function mocks batch transaction validatijon against a set of valid HotShot headers.
+// This function mocks batch transaction validation against a set of valid HotShot headers.
 // It pretends to verify that the set of transactions (txns) in a batch correspond to a set of n NMT proofs
 // (p1, ... pn) against headers h1,...hn.
-//
-// We assume that his function makes an external call to fetch the block headers beteen firstBlock and lastBlock.
 //
 // In other words, the function validates that txns = {...p1.txns, ..., ...pn.txns}. And that
 // p1, ..., pn are all valid NMT proofs with respect to r1, ..., rn, the NMT roots of each header.
 //
 // The first and last block headers are also necessary to validate that the the NMT proofs are consistent with
 // the transaction roots at the start and end of the window.
+//
+// We assume that his function makes an external call to fetch the block headers between firstBlock and lastBlock.
 func ValidateBatchTransactions(transactions []hexutil.Bytes, nmtProofs []NmtProof, firstBlock Header, lastBlockHeader Header, firstBlockNumber uint64) error {
-	// Even without true NMT verification, we can at least check that the number of NMT proofs is consistent
-	// with the distance between the first and last block headers
 	return nil
 }


### PR DESCRIPTION
Still many TODOs, but made some progress validating the following batch constraint cases:
1. HotShot skips a block and sequencer provides nil payload
2. HotShot does not provide any transactions in the window, sequencer increments L1 origin and provides nil payload
3. HotShot provides transactions in the the window, sequencer provides a payload

Also created another batch test file for espresso-specific cases (includes some of the default batch validation cases)