### PR TITLE
Improve selection of L1 origin in Espresso mode

### DIFF
--- a/op-node/rollup/derive/batch_queue_test.go
+++ b/op-node/rollup/derive/batch_queue_test.go
@@ -105,7 +105,7 @@ func TestBatchQueueNewOrigin(t *testing.T) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 	require.Equal(t, []eth.L1BlockRef{l1[0]}, bq.l1Blocks)
 
@@ -167,7 +167,7 @@ func TestBatchQueueEager(t *testing.T) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 	// Advance the origin
 	input.origin = l1[1]
@@ -217,7 +217,7 @@ func TestBatchQueueInvalidInternalAdvance(t *testing.T) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
 	// Load continuous batches for epoch 0
@@ -311,7 +311,7 @@ func TestBatchQueueMissing(t *testing.T) {
 		origin:  l1[0],
 	}
 
-	bq := NewBatchQueue(log, cfg, input)
+	bq := NewBatchQueue(log, cfg, input, nil)
 	_ = bq.Reset(context.Background(), l1[0], eth.SystemConfig{})
 
 	for i := 0; i < len(batches); i++ {

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -168,7 +168,7 @@ func CheckBatchEspresso(cfg *rollup.Config, log log.Logger, l2SafeHead eth.L2Blo
 		proofs := make([]*espresso.NmtProof, len(jst.Blocks))
 		for i, block := range jst.Blocks {
 			roots[i] = &block.Header.TransactionsRoot
-			proofs[i] = block.Proof
+			proofs[i] = &block.Proof
 		}
 		txs := make([]espresso.Bytes, len(batch.Batch.Transactions))
 		for i, tx := range batch.Batch.Transactions {

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -1,6 +1,8 @@
 package derive
 
 import (
+	"context"
+
 	"github.com/ethereum-optimism/optimism/op-node/rollup"
 	"github.com/ethereum-optimism/optimism/op-service/espresso"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
@@ -26,145 +28,166 @@ const (
 	BatchFuture
 )
 
-func CheckBatchEspresso(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, hotshot HotShotContractProvider) BatchValidity {
-	// First, validate the headers that represent the beginning of the L2 block range of this batch.
+// Find the L1 origin which is required of an L2 block built on `parent` when running in Espresso
+// mode. `suggested` is the L1 origin "suggested" by the Espresso Sequencer; namely, the L1 head
+// referenced by the first Espresso block after the end of the sequencing window for this L2 block.
+// If `suggested` is a valid L1 origin according to the rules of the derivation pipeline (e.g. it is
+// not too old for the L2 batch, it did not skip an L1 block from `parent.L1Origin`, etc.) its
+// number will be returned. Otherwise, a different L1 origin will be selected _deterministically_ to
+// conform with the constraints of the derivation pipeline. The resulting L1 origin will always be
+// the same as parent's or one block after parent's, will always conform to the derivation
+// constraints, and is deterministic given `parent` and `suggested.`
+func EspressoL1Origin(cfg *rollup.Config, parent eth.L2BlockRef, suggested eth.L1BlockRef) uint64 {
+	prev := parent.L1Origin
+	windowStart := parent.Time + cfg.BlockTime
+
+	// Constraint 1: the L1 origin must not skip an L1 block.
+	if suggested.Number > prev.Number+1 {
+		// If we did skip an L1 block, that is Espresso telling us that multiple new L1 blocks have
+		// already been produced. In this case, we will not block when fetching the next L1 origin,
+		// so advance as far as the derivation pipeline allows: one block.
+		return prev.Number + 1
+	}
+	// Constraint 2: the L1 origin number decreased.
+	//
+	// While Espresso _should_ guarantee that L1 origin numbers are monotonically increasing, a
+	// limitation in the current design means that on rare occasions the L1 origin number can
+	// decrease.
+	if suggested.Number < prev.Number {
+		// In this case, we have no indication that new L1 blocks are ready. We don't want to
+		// advance the L1 origin number and force the derivation pipeline to block waiting for a new
+		// L1 block to be produced, so just reuse the previous L1 origin.
+		return prev.Number
+	}
+	// Constraint 3: the L1 origin is too old.
+	if suggested.Time+cfg.MaxSequencerDrift < windowStart {
+		// Again, we have no explicit indication that new L1 blocks are ready, but here we are
+		// forced to advance the L1 origin. At worst, the derivation pipeline may block until the
+		// next L1 origin is available, but if the chosen L1 origin is this old, it is likely that a
+		// new L1 block is available and Espresso just hasn't seen it yet for some reason.
+		return prev.Number + 1
+	}
+	// Constraint 4: the L1 origin must not be newer than the L2 batch.
+	if suggested.Time > windowStart {
+		// In this case `suggested` must be `prev.Number + 1`, since `prev.Number` would have a
+		// timestamp earlier than `prev`, and thus earlier than the current batch. Espresso must be
+		// running ahead of the L2, which is fine, we'll just wait to advance the L1 origin until
+		// the L2 chain catches up.
+		return prev.Number
+	}
+
+	// In all other cases, the suggested L1 origin is valid.
+	return suggested.Number
+}
+
+func EspressoBatchMustBeEmpty(cfg *rollup.Config, l1Origin eth.L1BlockRef, timestamp uint64) bool {
+	// The constraints of the derivation pipeline require that if the L2 has fallen behind the L1
+	// and is catching up, it must produce empty batches.
+	return l1Origin.Time+cfg.MaxSequencerDrift < timestamp
+}
+
+func CheckBatchEspresso(cfg *rollup.Config, log log.Logger, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, l1 EspressoL1Provider) BatchValidity {
 	jst := batch.Batch.Justification
 	if jst == nil {
-		// Espresso blocks must have a justification
-		log.Warn("No justification provided, dropping the batch.")
+		log.Warn("dropping batch because it has no justification")
 		return BatchDrop
 	}
-	// Case where the start of the window is the genesis block
-	genesisStart := jst.FirstBlockNumber == 0
-	var startHeaders []espresso.Header
-	var firstBlockHeight uint64
 
-	if genesisStart {
-		startHeaders =
-			[]espresso.Header{jst.FirstBlock}
-		firstBlockHeight = 0
-	} else {
-		startHeaders =
-			[]espresso.Header{jst.PrevBatchLastBlock, jst.FirstBlock}
-		firstBlockHeight = jst.FirstBlockNumber - 1
+	// First, check that the headers provided by the justification match those in the sequencer
+	// contract. Compute their commitments which we can compare to the sequencer contract.
+	firstComm := jst.From
+	var comms []espresso.Commitment
+	if jst.Prev != nil {
+		firstComm -= 1
+		comms = append(comms, jst.Prev.Commit())
 	}
-
-	validHeaders, err := hotshot.verifyHeaders(startHeaders, firstBlockHeight)
-
-	// In the case that the headers aren't available yet (perhaps the validator's L1 client is behind), return BatchFuture so that we can try again later
-	// If the headers are available but invalid, drop the batch
+	for _, b := range jst.Blocks {
+		comms = append(comms, b.Header.Commit())
+	}
+	comms = append(comms, jst.Next.Commit())
+	// Compare to the authenticated commitments from the contract.
+	validComms, err := l1.VerifyCommitments(firstComm, comms)
 	if err != nil {
-		log.Warn("Headers unavailable, returning BatchFuture.")
-		return BatchFuture
-	} else if !validHeaders {
-		log.Warn("Headers invalid, dropping the batch.")
+		// If we can't read the expected commitments for some reason (maybe they haven't been sent
+		// to the sequencer contract yet, or maybe our connection to the L1 is down) try again
+		// later.
+		log.Warn("error reading expected commitments", "err", err, "first", firstComm, "count", len(comms))
+		return BatchUndecided
+	}
+	if !validComms {
+		log.Warn("dropping batch because headers do not match contract")
 		return BatchDrop
 	}
 
-	// First, check for cases where it is valid to have any empty batch.
+	// The headers claimed by the justification are all legitimate, now check that they correctly
+	// define the start and end of the time window.
 	windowStart := l2SafeHead.Time + cfg.BlockTime
 	windowEnd := windowStart + cfg.BlockTime
-	payload := jst.Payload
-	prevL1Origin := l2SafeHead.L1Origin
-
-	// Ensure that the sequencer did not cheat by choosing a previous block that is within the sequencing window
-	// Slightly redundant to the validRange check, but we need this check first to ensure that we don't get incorrect empty batches in the nil cases below
-	if jst.FirstBlockNumber != 0 && jst.PrevBatchLastBlock.Timestamp >= windowStart {
-		log.Warn("Dropping batch. The previous batch last block cannot be past the start of the sequencing window")
+	if !checkBookends(log, windowStart, jst, WindowStart) {
+		return BatchDrop
+	}
+	if !checkBookends(log, windowEnd, jst, WindowEnd) {
 		return BatchDrop
 	}
 
-	// If Espresso did not produce any blocks in this window, an empty batch is valid.
-	// In this case, the L1 origin must be the same as the previous block.
-	if payload == nil && jst.FirstBlock.Timestamp >= windowEnd {
-		if uint64(batch.Batch.EpochNum) != prevL1Origin.Number {
-			log.Warn("Dropping batch. When HotShot has not seqeuenced anything in the batch window, the L1 origin must be the same as the prior block")
+	// The Espresso data in the justification is good. Check that the L2 batch is correctly derived
+	// from the Espresso blocks. First, the L1 origin:
+	suggestedL1Origin, err := l1.L1BlockRefByNumber(context.Background(), jst.Next.L1Head)
+	if err != nil {
+		// If we can't read the suggested L1 origin for some reason (maybe our L1 client is lagging
+		// behind Espresso's view of the L1) try again later.
+		log.Warn("error reading suggested L1 origin", "err", err, "l1 head", jst.Next.L1Head)
+		return BatchUndecided
+	}
+	expectedL1Origin := EspressoL1Origin(cfg, l2SafeHead, suggestedL1Origin)
+	actualL1Origin := uint64(batch.Batch.EpochNum)
+	if expectedL1Origin != actualL1Origin {
+		log.Warn("dropping batch because L1 origin was not set correctly",
+			"suggested", jst.Next.L1Head, "expected", expectedL1Origin, "actual", actualL1Origin)
+		return BatchDrop
+	}
+	// Fetch details for the actual L1 origin.
+	var l1Origin eth.L1BlockRef
+	if actualL1Origin == suggestedL1Origin.Number {
+		l1Origin = suggestedL1Origin
+	} else {
+		l1Origin, err = l1.L1BlockRefByNumber(context.Background(), actualL1Origin)
+		if err != nil {
+			log.Warn("error reading actual L1 origin", "err", err, "origin", actualL1Origin)
+			return BatchUndecided
+		}
+	}
+	// Finally, the transactions:
+	if EspressoBatchMustBeEmpty(cfg, l1Origin, batch.Batch.Timestamp) {
+		if len(batch.Batch.Transactions) != 0 {
+			log.Warn("dropping batch because it must be empty but isn't")
 			return BatchDrop
 		}
-		return BatchAccept
-	}
-
-	// An empty batch can also be valid if the L1 origin is too far behind (either due to lag, or because HotShot skipped a block)
-	// In this case, the L1 origin must increase by one
-	skippedL1Block := jst.FirstBlock.L1Head > prevL1Origin.Number
-	if payload == nil && skippedL1Block {
-		if uint64(batch.Batch.EpochNum) != prevL1Origin.Number+1 {
-			log.Warn("Dropping batch because the L1 origin did not increase by one")
+	} else {
+		roots := make([]*espresso.NmtRoot, len(jst.Blocks))
+		proofs := make([]*espresso.NmtProof, len(jst.Blocks))
+		for i, block := range jst.Blocks {
+			roots[i] = &block.Header.TransactionsRoot
+			proofs[i] = block.Proof
+		}
+		txs := make([]espresso.Bytes, len(batch.Batch.Transactions))
+		for i, tx := range batch.Batch.Transactions {
+			txs[i] = []byte(tx)
+		}
+		err = espresso.ValidateBatchTransactions(cfg.L2ChainID.Uint64(), roots, proofs, txs)
+		if err != nil {
+			log.Warn("dropping batch because of invalid NMT proofs", "err", err)
 			return BatchDrop
 		}
-		return BatchAccept
-	}
-
-	// At this point, there is no valid reason to have an empty payload
-	if payload == nil {
-		log.Warn("Dropping batch due to empty payload")
-		return BatchDrop
-	}
-
-	// Now validate the transactions in the batch
-	numBlocks := len(payload.NmtProofs)
-
-	// Validate the headers representing the end of the batch window
-	endHeaders :=
-		[]espresso.Header{payload.LastBlock, payload.NextBatchFirstBlock}
-	validHeaders, err = hotshot.verifyHeaders(endHeaders, jst.FirstBlockNumber+uint64(numBlocks)-1)
-
-	// In the case that the headers aren't available yet (perhaps the validator's L1 client is behind), return BatchFuture so that we can try again later
-	// If the headers are available but invalid, drop the batch
-	if err != nil {
-		log.Warn("Headers unavailable, returning BatchFuture.")
-		return BatchFuture
-	} else if !validHeaders {
-		log.Warn("Headers invalid, dropping the batch.")
-		return BatchDrop
-	}
-
-	// Check that the range of HotShot blocks fall within the window
-	validRange :=
-		jst.PrevBatchLastBlock.Timestamp < windowStart &&
-			jst.FirstBlock.Timestamp >= windowStart &&
-			payload.LastBlock.Timestamp < windowEnd &&
-			payload.NextBatchFirstBlock.Timestamp >= windowEnd
-
-	if !validRange {
-		log.Warn("Header range invalid, dropping the batch.")
-		return BatchDrop
-	}
-
-	// Sanity check that the number of NMT proofs is at least 1 if the first and last block in the range are the same,
-	// and at least 2 otherwise. This check would redundant to the ValidateBatchTransactions function below if
-	// that function weren't mocked.
-	var minimumNMTProofs = 1
-	if jst.FirstBlock.Timestamp != jst.Payload.LastBlock.Timestamp {
-		minimumNMTProofs = 2
-	}
-
-	if len(payload.NmtProofs) < minimumNMTProofs {
-		log.Warn("Dropping batch, minimum NMT proofs required: ", minimumNMTProofs)
-		return BatchDrop
-	}
-
-	// Validate the transactions against the NMT proofs
-	headers, err := hotshot.getHeadersFromHeight(firstBlockHeight, uint64(len(payload.NmtProofs)))
-	if err != nil {
-		// If we couldn't fetch headers, try again later
-		log.Warn("Headers unavailable, returning BatchFuture.")
-		return BatchFuture
-	}
-	err = espresso.ValidateBatchTransactions(batch.Batch.Transactions, payload.NmtProofs, headers)
-	if err != nil {
-		log.Warn("Error validating batch transactions, dropping the batch.")
-		return BatchDrop
 	}
 
 	return BatchAccept
-
 }
 
 // CheckBatch checks if the given batch can be applied on top of the given l2SafeHead, given the contextual L1 blocks the batch was included in.
 // The first entry of the l1Blocks should match the origin of the l2SafeHead. One or more consecutive l1Blocks should be provided.
 // In case of only a single L1 block, the decision whether a batch is valid may have to stay undecided.
-func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, usingEspresso bool, hotshot HotShotContractProvider) BatchValidity {
+func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l2SafeHead eth.L2BlockRef, batch *BatchWithL1InclusionBlock, usingEspresso bool, l1 EspressoL1Provider) BatchValidity {
 	// add details to the log
 	log = log.New(
 		"batch_timestamp", batch.Batch.Timestamp,
@@ -250,7 +273,7 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 				// If Espresso is sequencing, the sequencer cannot adopt the next origin in the case
 				// that HotShot failed to sequence any blocks
 				if !usingEspresso && batch.Batch.Timestamp >= nextOrigin.Time { // check if the next L1 origin could have been adopted
-					log.Info("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid")
+					log.Warn("batch exceeded sequencer time drift without adopting next origin, and next L1 origin would have been valid")
 					return BatchDrop
 				} else {
 					log.Info("continuing with empty batch before late L1 block to preserve L2 time invariant")
@@ -276,8 +299,77 @@ func CheckBatch(cfg *rollup.Config, log log.Logger, l1Blocks []eth.L1BlockRef, l
 		}
 	}
 	if usingEspresso {
-		return CheckBatchEspresso(cfg, log, l1Blocks, l2SafeHead, batch, hotshot)
+		return CheckBatchEspresso(cfg, log, l2SafeHead, batch, l1)
 	} else {
 		return BatchAccept
 	}
+}
+
+// Check that the starting or ending bookend blocks of an Espresso block range surround the given
+// starting or ending timestamp.
+func checkBookends(log log.Logger, timestamp uint64, jst *eth.L2BatchJustification, endpoint windowEndpoint) bool {
+	prev, next := endpoint.Bookends(jst)
+	if prev == nil {
+		// It is allowed that there is no Espresso block just before the endpoint only in the case
+		// where the Espresso genesis block falls after the endpoint.
+		if jst.From != 0 || next.Timestamp < timestamp {
+			log.Warn("dropping batch because prev header is missing, but genesis is not after endpoint",
+				"endpoint", endpoint.String(), "from", jst.From, "next", next, "timestamp", timestamp)
+			return false
+		}
+	} else {
+		if prev.Timestamp >= timestamp {
+			log.Warn("dropping batch because prev header is from after the endpoint",
+				"endpoint", endpoint.String(), "prev", prev, "timestamp", timestamp)
+			return false
+		}
+		if next.Timestamp < timestamp {
+			log.Warn("dropping batch because next header is from before the endpoint",
+				"endpoint", endpoint.String(), "next", next, "timestamp", timestamp)
+			return false
+		}
+	}
+
+	return true
+}
+
+type windowEndpoint int
+
+const (
+	WindowStart windowEndpoint = iota
+	WindowEnd
+)
+
+func (e windowEndpoint) String() string {
+	return [...]string{"WindowStart", "WindowEnd"}[e]
+}
+
+func (e windowEndpoint) Bookends(jst *eth.L2BatchJustification) (prev *espresso.Header, next espresso.Header) {
+	switch e {
+	case WindowStart:
+		// The bookend just before the start of the window is always `jst.Prev`. If it doesn't
+		// exist, it's because the genesis falls in or after the window.
+		prev = jst.Prev
+		if len(jst.Blocks) != 0 {
+			// If the window is not empty, the first block in the window defines the start of the
+			// window.
+			next = jst.Blocks[0].Header
+		} else {
+			// Otherwise, the window is empty, and the place where its starting point would be is
+			// defined by the first block after the end of the window.
+			next = *jst.Next
+		}
+	case WindowEnd:
+		if len(jst.Blocks) != 0 {
+			// If the window is not empty, the last bock defines its end.
+			prev = &jst.Blocks[len(jst.Blocks)-1].Header
+		} else {
+			// Otherwise, the first block before where the window would be defines the end of the
+			// window. If it doesn't exist, it's because the genesis falls after the window.
+			prev = jst.Prev
+		}
+		// The end of the window is always defined by the first block after the time range.
+		next = *jst.Next
+	}
+	return
 }

--- a/op-node/rollup/derive/batches.go
+++ b/op-node/rollup/derive/batches.go
@@ -362,7 +362,7 @@ func (e windowEndpoint) Bookends(jst *eth.L2BatchJustification) (prev *espresso.
 		}
 	case WindowEnd:
 		if len(jst.Blocks) != 0 {
-			// If the window is not empty, the last bock defines its end.
+			// If the window is not empty, the last block defines its end.
 			prev = &jst.Blocks[len(jst.Blocks)-1].Header
 		} else {
 			// Otherwise, the first block before where the window would be defines the end of the

--- a/op-node/rollup/derive/batches_espresso_test.go
+++ b/op-node/rollup/derive/batches_espresso_test.go
@@ -1,8 +1,10 @@
 package derive
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"math/big"
 	"math/rand"
 	"testing"
 
@@ -13,7 +15,10 @@ import (
 	"github.com/ethereum-optimism/optimism/op-node/testutils"
 	"github.com/ethereum-optimism/optimism/op-service/espresso"
 	"github.com/ethereum-optimism/optimism/op-service/eth"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -26,35 +31,40 @@ type EspressoValidBatchTestCase struct {
 	Headers    []espresso.Header
 }
 
-type mockHotShotProvider struct {
-	Headers []espresso.Header
+type mockL1Provider struct {
+	L1Blocks []eth.L1BlockRef
+	Headers  []espresso.Header
 }
 
-func (m *mockHotShotProvider) verifyHeaders(headers []espresso.Header, height uint64) (bool, error) {
-	if height+uint64(len(headers)) > uint64(len(m.Headers)) {
-		fmt.Println("Headers unavailable")
+func (m *mockL1Provider) L1BlockRefByNumber(ctx context.Context, num uint64) (eth.L1BlockRef, error) {
+	if num >= uint64(len(m.L1Blocks)) {
+		return eth.L1BlockRef{}, fmt.Errorf("L1 block number %d not available", num)
+	}
+	return m.L1Blocks[num], nil
+}
+
+func (m *mockL1Provider) FetchReceipts(ctx context.Context, blockHash common.Hash) (eth.BlockInfo, types.Receipts, error) {
+	return nil, nil, fmt.Errorf("not implemented: FetchReceipts")
+}
+
+func (m *mockL1Provider) VerifyCommitments(firstBlockHeight uint64, comms []espresso.Commitment) (bool, error) {
+	if int(firstBlockHeight)+len(comms) > len(m.Headers) {
 		return false, NewCriticalError(errors.New("Headers unavailable"))
 	}
-	// For testing purposes, use the timestamp to check equality
-	for i, header := range headers {
-		if header.Timestamp != m.Headers[uint64(i)+height].Timestamp {
-			fmt.Println("Invalid header")
-			return false, nil
 
+	for i, comm := range comms {
+		if !comm.Equals(m.Headers[int(firstBlockHeight)+i].Commit()) {
+			return false, nil
 		}
 	}
 	return true, nil
 }
 
-func (m *mockHotShotProvider) getHeadersFromHeight(firstBlockHeight uint64, numHeaders uint64) ([]espresso.Header, error) {
-	if firstBlockHeight+numHeaders > uint64(len(m.Headers)) {
-		fmt.Println("Headers unavailable")
-		return nil, NewCriticalError(errors.New("Headers unavailable"))
-	}
-	return m.Headers[firstBlockHeight : firstBlockHeight+numHeaders], nil
+func (m *mockL1Provider) setBlocks(blocks []eth.L1BlockRef) {
+	m.L1Blocks = blocks
 }
 
-func (m *mockHotShotProvider) setHeaders(headers []espresso.Header) {
+func (m *mockL1Provider) setHeaders(headers []espresso.Header) {
 	m.Headers = headers
 }
 
@@ -74,11 +84,17 @@ func TestValidBatchEspresso(t *testing.T) {
 		BlockTime:         2,
 		SeqWindowSize:     4,
 		MaxSequencerDrift: 6,
+		L2ChainID:         big.NewInt(901),
 		// other config fields are ignored and can be left empty.
 	}
 
 	rng := rand.New(rand.NewSource(1234))
-	l1A := testutils.RandomBlockRef(rng)
+	l1A := eth.L1BlockRef{
+		Hash:       testutils.RandomHash(rng),
+		Number:     0,
+		ParentHash: testutils.RandomHash(rng),
+		Time:       rng.Uint64(),
+	}
 	l1B := eth.L1BlockRef{
 		Hash:       testutils.RandomHash(rng),
 		Number:     l1A.Number + 1,
@@ -137,15 +153,16 @@ func TestValidBatchEspresso(t *testing.T) {
 		SequenceNumber: 0,
 	}
 
-	// Two valid windows, one with a hotshot block in between the first and last blocks
+	// Three valid windows, with varying numbers of HotShot blocks in the window.
 	hotshotHeaders := []espresso.Header{
 		makeHeader(l2A1.Time - 1),
 		makeHeader(l2A1.Time),
-		makeHeader(l2A2.Time - 1),
 		makeHeader(l2A2.Time),
 		makeHeader(l2A2.Time + 1),
-		makeHeader(l2A3.Time - 1),
 		makeHeader(l2A3.Time),
+		makeHeader(l2A3.Time + 1),
+		makeHeader(l2A3.Time + 1),
+		makeHeader(l2A3.Time + conf.BlockTime),
 	}
 
 	// Hotshot skipped an L1 block
@@ -159,13 +176,19 @@ func TestValidBatchEspresso(t *testing.T) {
 				L1Head:    l2A3.L1Origin.Number + 2,
 			},
 		},
+		{
+			Metadata: espresso.Metadata{
+				Timestamp: l2B0.Time + conf.BlockTime,
+				L1Head:    l2A3.L1Origin.Number + 2,
+			},
+		},
 	}
 
 	// Case where Hotshot window is genuinely empty
 	emptyHotshotWindowHeaders :=
 		[]espresso.Header{
-			makeHeader(l2B0.Time - 1),
-			makeHeader(l2B0.Time + 1000),
+			makeHeader(l2A1.Time - 1),
+			makeHeader(l2A1.Time + 1000),
 		}
 
 	// Case where Espresso tries to fool validator by providing a previous batch last block
@@ -174,11 +197,12 @@ func TestValidBatchEspresso(t *testing.T) {
 		[]espresso.Header{
 			makeHeader(l2B0.Time - 1),
 			makeHeader(l2B0.Time + 1000),
+			makeHeader(l2B0.Time + 1001),
 		}
 
 	testCases := []EspressoValidBatchTestCase{
 		{
-			Name:       "valid batch where hotshot transactions fall within the window",
+			Name:       "valid batch where one hotshot block falls within the window",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
 			L2SafeHead: l2A0,
 			Headers:    hotshotHeaders,
@@ -192,24 +216,22 @@ func TestValidBatchEspresso(t *testing.T) {
 						Timestamp:  l2A1.Time,
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: hotshotHeaders[0],
-						FirstBlock:         hotshotHeaders[1],
-						FirstBlockNumber:   1,
-						Payload: &eth.L2BatchPayloadJustification{
-							LastBlock:           hotshotHeaders[2],
-							NextBatchFirstBlock: hotshotHeaders[3],
-							NmtProofs: []espresso.Bytes{
-								[]byte{0x02, 0x42, 0x13, 0x37},
-								[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+						Prev: &hotshotHeaders[0],
+						From: 1,
+						Blocks: []eth.EspressoBlockJustification{
+							{
+								Header: hotshotHeaders[1],
+								Proof:  nil,
 							},
 						},
+						Next: &hotshotHeaders[2],
 					},
 				}},
 			},
 			Expected: BatchAccept,
 		},
 		{
-			Name:       "valid batch where hotshot transactions fall within the window and there is a block in between first and last block",
+			Name:       "valid batch where two hotshot blocks fall within the window",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
 			L2SafeHead: l2A1,
 			Headers:    hotshotHeaders,
@@ -223,18 +245,56 @@ func TestValidBatchEspresso(t *testing.T) {
 						Timestamp:  l2A2.Time,
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: hotshotHeaders[2],
-						FirstBlock:         hotshotHeaders[3],
-						FirstBlockNumber:   3,
-						Payload: &eth.L2BatchPayloadJustification{
-							LastBlock:           hotshotHeaders[5],
-							NextBatchFirstBlock: hotshotHeaders[6],
-							NmtProofs: []espresso.Bytes{
-								[]byte{0x02, 0x42, 0x13, 0x37},
-								[]byte{0x02, 0x42, 0x13, 0x37},
-								[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+						Prev: &hotshotHeaders[1],
+						From: 2,
+						Blocks: []eth.EspressoBlockJustification{
+							{
+								Header: hotshotHeaders[2],
+								Proof:  nil,
+							},
+							{
+								Header: hotshotHeaders[3],
+								Proof:  nil,
 							},
 						},
+						Next: &hotshotHeaders[4],
+					},
+				}},
+			},
+			Expected: BatchAccept,
+		},
+		{
+			Name:       "valid batch where three hotshot blocks fall within the window",
+			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
+			L2SafeHead: l2A2,
+			Headers:    hotshotHeaders,
+			Batch: BatchWithL1InclusionBlock{
+				L1InclusionBlock: l1A,
+				Batch: &BatchData{BatchV2{
+					BatchV1: BatchV1{
+						ParentHash: l2A3.ParentHash,
+						EpochNum:   rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:  l2A3.L1Origin.Hash,
+						Timestamp:  l2A3.Time,
+					},
+					Justification: &eth.L2BatchJustification{
+						Prev: &hotshotHeaders[3],
+						From: 4,
+						Blocks: []eth.EspressoBlockJustification{
+							{
+								Header: hotshotHeaders[4],
+								Proof:  nil,
+							},
+							{
+								Header: hotshotHeaders[5],
+								Proof:  nil,
+							},
+							{
+								Header: hotshotHeaders[6],
+								Proof:  nil,
+							},
+						},
+						Next: &hotshotHeaders[7],
 					},
 				}},
 			},
@@ -243,28 +303,28 @@ func TestValidBatchEspresso(t *testing.T) {
 		{
 			Name:       "empty batch due to empty hotshot window",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
-			L2SafeHead: l2A3,
+			L2SafeHead: l2A0,
 			Headers:    emptyHotshotWindowHeaders,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1A,
 				Batch: &BatchData{BatchV2{
 					BatchV1: BatchV1{
-						ParentHash: l2B0.ParentHash,
-						EpochNum:   rollup.Epoch(l2A0.L1Origin.Number),
-						EpochHash:  l2A0.L1Origin.Hash,
-						Timestamp:  l2B0.Time,
+						ParentHash: l2A1.ParentHash,
+						EpochNum:   rollup.Epoch(l2A1.L1Origin.Number),
+						EpochHash:  l2A1.L1Origin.Hash,
+						Timestamp:  l2A1.Time,
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: emptyHotshotWindowHeaders[0],
-						FirstBlock:         emptyHotshotWindowHeaders[1],
-						FirstBlockNumber:   1,
+						Prev: &emptyHotshotWindowHeaders[0],
+						Next: &emptyHotshotWindowHeaders[1],
+						From: 1,
 					},
 				}},
 			},
 			Expected: BatchAccept,
 		},
 		{
-			Name:       "empty batch due to hotshot skipping an L1 block",
+			Name:       "valid batch where HotShot skips an L1 block",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
 			L2SafeHead: l2A3,
 			Headers:    hotshotSkippedHeaders,
@@ -279,9 +339,15 @@ func TestValidBatchEspresso(t *testing.T) {
 						Transactions: []hexutil.Bytes{},
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: hotshotSkippedHeaders[0],
-						FirstBlock:         hotshotSkippedHeaders[1],
-						FirstBlockNumber:   1,
+						Prev: &hotshotSkippedHeaders[0],
+						Blocks: []eth.EspressoBlockJustification{
+							{
+								Header: hotshotSkippedHeaders[1],
+								Proof:  nil,
+							},
+						},
+						Next: &hotshotSkippedHeaders[2],
+						From: 1,
 					},
 				}},
 			},
@@ -304,9 +370,9 @@ func TestValidBatchEspresso(t *testing.T) {
 					},
 					Justification: &eth.L2BatchJustification{
 						// Switch the blocks
-						PrevBatchLastBlock: hotshotSkippedHeaders[1],
-						FirstBlock:         hotshotSkippedHeaders[0],
-						FirstBlockNumber:   1,
+						Prev: &hotshotSkippedHeaders[1],
+						Next: &hotshotSkippedHeaders[0],
+						From: 1,
 					},
 				}},
 			},
@@ -328,9 +394,15 @@ func TestValidBatchEspresso(t *testing.T) {
 						Transactions: []hexutil.Bytes{},
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: hotshotDishonestHeaders[0],
-						FirstBlock:         hotshotDishonestHeaders[1],
-						FirstBlockNumber:   1,
+						Prev: &hotshotDishonestHeaders[0],
+						Blocks: []eth.EspressoBlockJustification{
+							{
+								Header: hotshotDishonestHeaders[1],
+								Proof:  nil,
+							},
+						},
+						Next: &hotshotDishonestHeaders[2],
+						From: 1,
 					},
 				}},
 			},
@@ -340,22 +412,28 @@ func TestValidBatchEspresso(t *testing.T) {
 			Name:     "invalid batch when hotshot skips an L1 block",
 			L1Blocks: []eth.L1BlockRef{l1A, l1B, l1C},
 			// In this case, the L1 origin wont increment
-			L2SafeHead: l2B0,
+			L2SafeHead: l2A3,
 			Headers:    hotshotSkippedHeaders,
 			Batch: BatchWithL1InclusionBlock{
 				L1InclusionBlock: l1B,
 				Batch: &BatchData{BatchV2{
 					BatchV1: BatchV1{
 						ParentHash:   l2B0.ParentHash,
-						EpochNum:     rollup.Epoch(l2B0.L1Origin.Number),
-						EpochHash:    l2B0.L1Origin.Hash,
+						EpochNum:     rollup.Epoch(l2A3.L1Origin.Number),
+						EpochHash:    l2A3.L1Origin.Hash,
 						Timestamp:    l2B0.Time,
 						Transactions: []hexutil.Bytes{},
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: hotshotSkippedHeaders[0],
-						FirstBlock:         hotshotSkippedHeaders[1],
-						FirstBlockNumber:   1,
+						Prev: &hotshotSkippedHeaders[0],
+						Blocks: []eth.EspressoBlockJustification{
+							{
+								Header: hotshotSkippedHeaders[1],
+								Proof:  nil,
+							},
+						},
+						Next: &hotshotSkippedHeaders[2],
+						From: 1,
 					},
 				}},
 			},
@@ -376,19 +454,21 @@ func TestValidBatchEspresso(t *testing.T) {
 						Timestamp:  l2A1.Time,
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: hotshotHeaders[0],
-						FirstBlock:         hotshotHeaders[1],
-						FirstBlockNumber:   1,
-						Payload: &eth.L2BatchPayloadJustification{
-							// Increment LastBlock and NextBatchFirstBlock from the valid test case by one
-							LastBlock:           hotshotHeaders[3],
-							NextBatchFirstBlock: hotshotHeaders[4],
-							NmtProofs: []espresso.Bytes{
-								[]byte{0x02, 0x42, 0x13, 0x37},
-								[]byte{0x02, 0x42, 0x13, 0x37},
-								[]byte{0x02, 0xde, 0xad, 0xbe, 0xef},
+						Prev: &hotshotHeaders[0],
+						Blocks: []eth.EspressoBlockJustification{
+							{
+								Header: hotshotHeaders[1],
+								Proof:  nil,
+							},
+							// Include an extra block that is outside the window
+							{
+								Header: hotshotHeaders[2],
+								Proof:  nil,
 							},
 						},
+						From: 1,
+						// Increment Next from the valid test case by one
+						Next: &hotshotHeaders[3],
 					},
 				}},
 			},
@@ -414,7 +494,7 @@ func TestValidBatchEspresso(t *testing.T) {
 			Expected: BatchDrop,
 		},
 		{
-			Name:       "future batch if headers are not available",
+			Name:       "undecided batch if headers are not available",
 			L1Blocks:   []eth.L1BlockRef{l1A, l1B, l1C},
 			L2SafeHead: l2A3,
 			Batch: BatchWithL1InclusionBlock{
@@ -427,25 +507,26 @@ func TestValidBatchEspresso(t *testing.T) {
 						Timestamp:  l2B0.Time,
 					},
 					Justification: &eth.L2BatchJustification{
-						PrevBatchLastBlock: emptyHotshotWindowHeaders[0],
-						FirstBlock:         emptyHotshotWindowHeaders[1],
-						FirstBlockNumber:   1,
+						Prev: &emptyHotshotWindowHeaders[0],
+						Next: &emptyHotshotWindowHeaders[1],
+						From: 1,
 					},
 				}},
 			},
-			Expected: BatchFuture,
+			Expected: BatchUndecided,
 		},
 	}
 
 	// Log level can be increased for debugging purposes
 	logger := testlog.Logger(t, log.LvlWarn)
 
-	var hotshot = &mockHotShotProvider{}
+	var l1 = &mockL1Provider{}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
-			hotshot.setHeaders(testCase.Headers)
-			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, true, hotshot)
+			l1.setBlocks(testCase.L1Blocks)
+			l1.setHeaders(testCase.Headers)
+			validity := CheckBatch(&conf, logger, testCase.L1Blocks, testCase.L2SafeHead, &testCase.Batch, true, l1)
 			require.Equal(t, testCase.Expected, validity, "batch check must return expected validity level")
 		})
 	}

--- a/op-node/rollup/derive/espresso_provider.go
+++ b/op-node/rollup/derive/espresso_provider.go
@@ -8,17 +8,20 @@ import (
 	"github.com/ethereum-optimism/optimism/op-service/eth"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 type EspressoProvider struct {
 	HotShotAddr common.Address
 	L1Fetcher   L1Fetcher
+	log         log.Logger
 }
 
-func NewEspressoProvider(hotshotAddr common.Address, l1Fetcher L1Fetcher) *EspressoProvider {
+func NewEspressoProvider(log log.Logger, hotshotAddr common.Address, l1Fetcher L1Fetcher) *EspressoProvider {
 	return &EspressoProvider{
 		HotShotAddr: hotshotAddr,
 		L1Fetcher:   l1Fetcher,
+		log:         log,
 	}
 
 }
@@ -35,6 +38,7 @@ func (provider *EspressoProvider) VerifyCommitments(firstHeight uint64, comms []
 
 	for i, comm := range comms {
 		if !comm.Equals(fetchedComms[i]) {
+			provider.log.Warn("commitment does not match expected", "first", firstHeight, "i", i, "comm", comm, "expected", fetchedComms[i])
 			return false, nil
 		}
 	}

--- a/op-node/rollup/derive/l1_block_info_tob_test.go
+++ b/op-node/rollup/derive/l1_block_info_tob_test.go
@@ -30,7 +30,7 @@ func FuzzParseL1InfoDepositTxDataValid(f *testing.F) {
 				if e.Proof == nil {
 					e.Proof = espresso.NmtProof{}
 				}
-			},)
+			})
 		fuzzerutils.AddFuzzerFunctions(typeProvider)
 
 		var l1Info testutils.MockBlockInfo

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -90,7 +90,7 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 	frameQueue := NewFrameQueue(log, l1Src)
 	bank := NewChannelBank(log, cfg, frameQueue, l1Fetcher, metrics)
 	chInReader := NewChannelInReader(log, bank, metrics)
-	batchQueue := NewBatchQueue(log, cfg, chInReader)
+	batchQueue := NewBatchQueue(log, cfg, chInReader, &FakeHotShot{l1Fetcher})
 	attrBuilder := NewFetchingAttributesBuilder(cfg, l1Fetcher, engine)
 	attributesQueue := NewAttributesQueue(log, cfg, attrBuilder, batchQueue)
 

--- a/op-node/rollup/derive/pipeline.go
+++ b/op-node/rollup/derive/pipeline.go
@@ -88,7 +88,7 @@ func NewDerivationPipeline(log log.Logger, cfg *rollup.Config, l1Fetcher L1Fetch
 
 	var espressoProvider EspressoL1Provider
 	if cfg.HotShotContractAddress != nil {
-		espressoProvider = NewEspressoProvider(*cfg.HotShotContractAddress, l1Fetcher)
+		espressoProvider = NewEspressoProvider(log, *cfg.HotShotContractAddress, l1Fetcher)
 	}
 	// Pull stages
 	l1Traversal := NewL1Traversal(log, cfg, l1Fetcher)

--- a/op-node/rollup/driver/sequencer.go
+++ b/op-node/rollup/driver/sequencer.go
@@ -152,7 +152,7 @@ func (d *Sequencer) updateEspressoBatch(ctx context.Context, newHeaders []espres
 		d.log.Info("adding new transactions from Espresso", "block", blockNum, "count", len(txs.Transactions))
 		batch.jst.Blocks = append(blocks, eth.EspressoBlockJustification{
 			Header: header,
-			Proof:  &txs.Proof,
+			Proof:  txs.Proof,
 		})
 		for _, tx := range txs.Transactions {
 			batch.transactions = append(batch.transactions, []byte(tx))
@@ -214,10 +214,10 @@ func (d *Sequencer) sealEspressoBatch(ctx context.Context) (*eth.ExecutionPayloa
 	if derive.EspressoBatchMustBeEmpty(d.config, l1Origin, batch.windowStart) {
 		batch.transactions = nil
 
-		// We don't need all the NMT proofs in this case, so save space in the batch by deleting
-		// them.
+		// We don't need all the NMT proofs in this case, so save space in the batch by replacing
+		// them with empty proofs.
 		for i := range batch.jst.Blocks {
-			batch.jst.Blocks[i].Proof = nil
+			batch.jst.Blocks[i].Proof = espresso.NmtProof{}
 		}
 	}
 

--- a/op-node/sources/l1_client.go
+++ b/op-node/sources/l1_client.go
@@ -135,8 +135,8 @@ func (s *L1Client) L1HotShotCommitmentsFromHeight(firstBlockHeight uint64, numHe
 	if err != nil {
 		return nil, err
 	}
-	if blockHeight.Cmp(big.NewInt(int64(firstBlockHeight + numHeaders))) < 0 {
-		return nil, fmt.Errorf("commitments up to %d are not available (current block height %d)", firstBlockHeight + numHeaders, blockHeight)
+	if blockHeight.Cmp(big.NewInt(int64(firstBlockHeight+numHeaders))) < 0 {
+		return nil, fmt.Errorf("commitments up to %d are not available (current block height %d)", firstBlockHeight+numHeaders, blockHeight)
 	}
 
 	for i := 0; i < int(numHeaders); i++ {
@@ -149,7 +149,7 @@ func (s *L1Client) L1HotShotCommitmentsFromHeight(firstBlockHeight uint64, numHe
 		for i, b := range comm.Bytes() {
 			// Bytes() returns the bytes in big endian order, but HotShot encodes commitments as
 			// U256 in little endian order, so we populate the bytes in reverse order.
-			bytes[31 - i] = b
+			bytes[31-i] = b
 		}
 
 		comms = append(comms, bytes)

--- a/op-node/testutils/random.go
+++ b/op-node/testutils/random.go
@@ -273,14 +273,13 @@ func RandomOutputResponse(rng *rand.Rand) *eth.OutputResponse {
 }
 
 func RandomL2BatchJustification(rng *rand.Rand) *eth.L2BatchJustification {
+	prev := RandomEspressoHeader(rng)
+	next := RandomEspressoHeader(rng)
 	return &eth.L2BatchJustification{
-		PrevBatchLastBlock: RandomEspressoHeader(rng),
-		FirstBlock:         RandomEspressoHeader(rng),
-		Payload: &eth.L2BatchPayloadJustification{
-			LastBlock:           RandomEspressoHeader(rng),
-			NextBatchFirstBlock: RandomEspressoHeader(rng),
-			NmtProofs:           make([]espresso.NmtProof, 0),
-		},
+		Prev:   &prev,
+		Next:   &next,
+		From:   RandomBlockID(rng).Number,
+		Blocks: make([]eth.EspressoBlockJustification, 0),
 	}
 }
 

--- a/op-service/espresso/commit.go
+++ b/op-service/espresso/commit.go
@@ -12,6 +12,28 @@ import (
 
 type Commitment [32]byte
 
+func CommitmentFromUint256(n *U256) (Commitment, error) {
+	var bytes [32]byte
+
+	bigEndian := n.Bytes()
+	if len(bigEndian) > 32 {
+		return Commitment{}, fmt.Errorf("integer out of range for U256 (%d)", n)
+	}
+
+	// `n` might have fewer than 32 bytes, if the commitment starts with one or more zeros. Pad out
+	// to 32 bytes exactly, adding zeros at the end to be consistent with big-endian byte order.
+	for len(bigEndian) < 32 {
+		bigEndian = append(bigEndian, 0)
+	}
+
+	for i, b := range bigEndian {
+		// Bytes() returns the bytes in big endian order, but HotShot encodes commitments as
+		// U256 in little endian order, so we populate the bytes in reverse order.
+		bytes[31-i] = b
+	}
+	return bytes, nil
+}
+
 func (c Commitment) Equals(other Commitment) bool {
 	return bytes.Equal(c[:], other[:])
 }

--- a/op-service/espresso/commit.go
+++ b/op-service/espresso/commit.go
@@ -1,6 +1,7 @@
 package espresso
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -10,6 +11,10 @@ import (
 )
 
 type Commitment [32]byte
+
+func (c Commitment) Equals(other Commitment) bool {
+	return bytes.Equal(c[:], other[:])
+}
 
 type RawCommitmentBuilder struct {
 	hasher crypto.KeccakState

--- a/op-service/espresso/nmt.go
+++ b/op-service/espresso/nmt.go
@@ -1,15 +1,11 @@
 package espresso
 
-import (
-	"github.com/ethereum/go-ethereum/common/hexutil"
-)
-
-// This function mocks batch transaction validation against a set of valid HotShot headers.
+// This function mocks batch transaction validation against a set of HotShot NMT roots.
 // It pretends to verify that the set of transactions (txns) in a batch correspond to a set of n NMT proofs
-// (p1, ... pn) against headers h1,...hn.
+// (p1, ... pn) against trusted NMT roots r1,...rn.
 //
-// In other words, the function validates that txns = {...p1.txns, ..., ...pn.txns}. And that
-// p1, ..., pn are all valid NMT proofs with respect to r1, ..., rn, the NMT roots of each header.
-func ValidateBatchTransactions(transactions []hexutil.Bytes, nmtProofs []NmtProof, headers []Header) error {
+// In other words, the function validates that txns = {...p1.txns, ..., ...pn.txns}, that all the transactions
+// come from the given namespace, and that p1, ..., pn are all valid NMT proofs with respect to r1, ..., rn.
+func ValidateBatchTransactions(namespace uint64, roots []*NmtRoot, proofs []*NmtProof, transactions []Bytes) error {
 	return nil
 }

--- a/op-service/espresso/types.go
+++ b/op-service/espresso/types.go
@@ -52,7 +52,6 @@ func (self *Header) Commit() Commitment {
 		OptionalField("l1_finalized", l1FinalizedComm).
 		Field("transactions_root", self.TransactionsRoot.Commit()).
 		Finalize()
-
 }
 
 type Metadata struct {

--- a/op-service/espresso/types.go
+++ b/op-service/espresso/types.go
@@ -244,6 +244,11 @@ func NewU256() *U256 {
 	return new(U256)
 }
 
+func (i *U256) SetBigInt(n *big.Int) *U256 {
+	i.Int.Set(n)
+	return i
+}
+
 func (i *U256) SetUint64(n uint64) *U256 {
 	i.Int.SetUint64(n)
 	return i

--- a/op-service/eth/types.go
+++ b/op-service/eth/types.go
@@ -247,9 +247,9 @@ type EspressoBlockJustification struct {
 	// The header of the Espresso block containing the range of transactions.
 	Header espresso.Header `json:"header"`
 	// Proof that a certain range of transactions corresponds to the Espresso block with Header.
-	// This proof may be omitted in the case where the L2 batch is forced to be empty due to its L1
+	// This proof may be empty in the case where the L2 batch is forced to be empty due to its L1
 	// origin being too old.
-	Proof *espresso.NmtProof `json:"proof" rlp:"nil"`
+	Proof espresso.NmtProof `json:"proof"`
 }
 
 // Justification for the inclusion of a range of Espresso blocks in an L2 batch.


### PR DESCRIPTION
We now apply corrections to the L1 origin _before_ deciding
whether the batch must be empty, which should lead to fewer
spurious empty batches.
    
We also use the L1 head of the _last_ Espresso block instead of the
first one, which gives us a more recent L1 origin. Since we must
always wait for the last block of the window to choose the L1
origin, the justification format and validation has fewer edge
cases. The justification will always have start and end bookends,
and the validation flow is simply:
* validate all headers
* check bookends
* check L1 origin
* check transactions
The only edge cases are in checking the bookends, where Prev may be
nil in the genesis case.

Depends on #57 
Depends on #55 (will need to rebase/fix conflicts)
    
Closes #52
Closes #53
