### PR TITLE
CI: build docker images in github action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -998,6 +998,9 @@ jobs:
           name: generate cannon prestate
           command: make cannon-prestate
       - run:
+          name: Build the stack
+          command: make devnet-build
+      - run:
           name: Bring up the stack
           command: make <<parameters.devnet-up>>
       - run:

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,68 @@
+name: Docker Images
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+      - integration
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  docker-l1:
+    uses: ./.github/workflows/docker.yml
+    with:
+        images: ghcr.io/espressosystems/op-espresso-integration/l1
+        context: ./ops-bedrock
+        dockerfile: ./ops-bedrock/Dockerfile.l1
+    secrets: inherit
+
+  docker-l2:
+    uses: ./.github/workflows/docker.yml
+    with:
+        images: ghcr.io/espressosystems/op-espresso-integration/l2
+        context: ./ops-bedrock
+        dockerfile: ./ops-bedrock/Dockerfile.l2
+    secrets: inherit
+
+  docker-stateviz:
+    uses: ./.github/workflows/docker.yml
+    with:
+        images: ghcr.io/espressosystems/op-espresso-integration/stateviz
+        context: .
+        dockerfile: ./ops-bedrock/Dockerfile.stateviz
+    secrets: inherit
+
+  docker-op-node:
+    uses: ./.github/workflows/docker.yml
+    with:
+        images: ghcr.io/espressosystems/op-espresso-integration/op-node
+        context: .
+        dockerfile: ./op-node/Dockerfile
+    secrets: inherit
+
+  docker-op-proposer:
+    uses: ./.github/workflows/docker.yml
+    with:
+        images: ghcr.io/espressosystems/op-espresso-integration/op-proposer
+        context: .
+        dockerfile: ./op-proposer/Dockerfile
+    secrets: inherit
+
+  docker-op-batcher:
+    uses: ./.github/workflows/docker.yml
+    with:
+        images: ghcr.io/espressosystems/op-espresso-integration/op-batcher
+        context: .
+        dockerfile: ./op-batcher/Dockerfile
+    secrets: inherit
+
+  docker-op-geth-proxy:
+    uses: ./.github/workflows/docker.yml
+    with:
+        images: ghcr.io/espressosystems/op-espresso-integration/op-geth-proxy
+        context: .
+        dockerfile: ./op-geth-proxy/Dockerfile
+    secrets: inherit
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Espresso Docker
+
+on:
+  workflow_call:
+    inputs:
+      images:
+        required: true
+        type: string
+      context:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+
+jobs:
+  build_and_push_docker_image:
+    name: Push Docker image to ghcr
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Github Container Repo
+        uses: docker/login-action@v2
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner  }}
+          password: ${{ secrets.GITHUB_TOKEN  }}
+
+      - name: Generate docker metadata
+        uses: docker/metadata-action@v4
+        id: metadata
+        with:
+          images: ${{ inputs.images }}
+
+      - name: Build and push docker
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ inputs.context }}
+          file: ${{ inputs.dockerfile }}
+          push: ${{ github.event_name != 'pull_request'  }}
+          tags: ${{ steps.metadata.outputs.tags  }}
+          labels: ${{ steps.metadata.outputs.labels  }}
+          platforms: linux/amd64,arm64

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ devnet-up-espresso:
 .PHONY: devnet-up-espresso
 
 devnet-up-espresso2:
-	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=. $(DEVNET_ESPRESSO_OP2_FLAGS) --deploy-l2 --skip-build
+	PYTHONPATH=./bedrock-devnet python3 ./bedrock-devnet/main.py --monorepo-dir=. $(DEVNET_ESPRESSO_OP2_FLAGS) --deploy-l2
 .PHONY: devnet-up-espresso2
 
 # alias for devnet-up

--- a/bedrock-devnet/devnet/__init__.py
+++ b/bedrock-devnet/devnet/__init__.py
@@ -26,8 +26,6 @@ parser.add_argument('--deploy-config', help='Deployment config, relative to pack
 parser.add_argument('--deployment', help='Path to deployment output files, relative to packages/contracts-bedrock/deployments', default='devnetL1')
 parser.add_argument('--devnet-dir', help='Output path for devnet config, relative to --monorepo-dir', default='.devnet')
 parser.add_argument('--espresso', help='Run on Espresso Sequencer', type=bool, action=argparse.BooleanOptionalAction)
-parser.add_argument('--skip-build', help='Skip building docker images', type=bool, action=argparse.BooleanOptionalAction)
-parser.add_argument('--build', help='Only build docker images', type=bool, action=argparse.BooleanOptionalAction)
 
 log = logging.getLogger()
 
@@ -99,19 +97,6 @@ def main():
 
     if args.allocs:
         devnet_l1_genesis(paths, args.deploy_config)
-        return
-
-    if args.skip_build:
-        log.warn('Skipping building docker images')
-    else:
-        log.info('Building docker images')
-        run_command(['docker', 'compose', 'build', '--progress', 'plain'], cwd=paths.ops_bedrock_dir, env={
-            'PWD': paths.ops_bedrock_dir,
-            'DEVNET_DIR': paths.devnet_dir
-        })
-
-    if args.build:
-        log.info("Finished building")
         return
 
     log.info('Devnet starting')

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -23,6 +23,7 @@ services:
   #
 
   l1:
+    image: ghcr.io/espressosystems/op-espresso-integration/l1:integration
     build:
       context: .
       dockerfile: Dockerfile.l1
@@ -40,6 +41,7 @@ services:
   #
 
   op1-l2:
+    image: ghcr.io/espressosystems/op-espresso-integration/l2:integration
     build:
       context: .
       dockerfile: Dockerfile.l2
@@ -57,6 +59,7 @@ services:
       - "--authrpc.jwtsecret=/config/test-jwt-secret.txt"
 
   op1-node:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-node:integration
     depends_on:
       - l1
       - op1-l2
@@ -102,6 +105,7 @@ services:
       - op1_log:/op_log
 
   op1-proposer:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-proposer:integration
     depends_on:
       - l1
       - op1-l2
@@ -125,6 +129,7 @@ services:
       OP_PROPOSER_ALLOW_NON_FINALIZED: "true"
 
   op1-batcher:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-batcher:integration
     depends_on:
       - l1
       - op1-l2
@@ -151,6 +156,7 @@ services:
       OP_BATCHER_RPC_ENABLE_ADMIN: "true"
 
   op1-geth-proxy:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-geth-proxy:integration
     build:
       context: ../
       dockerfile: ./op-geth-proxy/Dockerfile
@@ -176,6 +182,7 @@ services:
       - "no-new-privileges:true"
 
   stateviz:
+    image: ghcr.io/espressosystems/op-espresso-integration/stateviz:integration
     build:
       context: ../
       dockerfile: ./ops-bedrock/Dockerfile.stateviz
@@ -281,6 +288,7 @@ services:
   #
 
   op2-l2:
+    image: ghcr.io/espressosystems/op-espresso-integration/l2:integration
     build:
       context: .
       dockerfile: Dockerfile.l2
@@ -298,6 +306,7 @@ services:
       - "--authrpc.jwtsecret=/config/test-jwt-secret.txt"
 
   op2-node:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-node:integration
     depends_on:
       - l1
       - op2-l2
@@ -343,6 +352,7 @@ services:
       - op2_log:/op_log
 
   op2-proposer:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-proposer:integration
     depends_on:
       - l1
       - op2-l2
@@ -366,6 +376,7 @@ services:
       OP_PROPOSER_ALLOW_NON_FINALIZED: "true"
 
   op2-batcher:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-batcher:integration
     depends_on:
       - l1
       - op2-l2
@@ -392,6 +403,7 @@ services:
       OP_BATCHER_RPC_ENABLE_ADMIN: "true"
 
   op2-geth-proxy:
+    image: ghcr.io/espressosystems/op-espresso-integration/op-geth-proxy:integration
     build:
       context: ../
       dockerfile: ./op-geth-proxy/Dockerfile


### PR DESCRIPTION
It shouldn't be necessary to build docker images locally to run the
demo. This commit builds the OP images on ghcr and adds them as `image`
field to the docker compose file.

Remove build step from python devnet script. Use `make devnet-build` for
building if desired. This should allow running the demo with images from
ghcr without building them.

Add `make devnet-build` in the CI because `devnet-up` does not build
anymore.