### PR TITLE
Demo improvements

### DIFF
--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -523,6 +523,7 @@ services:
       - ESPRESSO_ORCHESTRATOR_NEXT_VIEW_TIMEOUT=10s
       - ESPRESSO_ORCHESTRATOR_MAX_PROPOSE_TIME=1s
       - RUST_LOG
+    stop_grace_period: 1s
 
   da-server:
     image: ghcr.io/espressosystems/espresso-sequencer/web-server:main
@@ -534,6 +535,7 @@ services:
     depends_on:
       orchestrator:
         condition: service_healthy
+    stop_grace_period: 1s
 
   consensus-server:
     image: ghcr.io/espressosystems/espresso-sequencer/web-server:main
@@ -545,6 +547,7 @@ services:
     depends_on:
       orchestrator:
         condition: service_healthy
+    stop_grace_period: 1s
 
   commitment-task:
     image: ghcr.io/espressosystems/espresso-sequencer/commitment-task:main
@@ -561,6 +564,7 @@ services:
         condition: service_healthy
       l1:
         condition: service_started
+    stop_grace_period: 1s
 
   sequencer0:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
@@ -582,6 +586,7 @@ services:
         condition: service_healthy
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    stop_grace_period: 1s
 
   sequencer1:
     image: ghcr.io/espressosystems/espresso-sequencer/sequencer:main
@@ -602,3 +607,4 @@ services:
         condition: service_healthy
     extra_hosts:
       - 'host.docker.internal:host-gateway'
+    stop_grace_period: 1s

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -239,6 +239,7 @@ services:
     env_file:
       - ../blockscout/docker-compose/envs/common-blockscout.env
     environment:
+        SUBNETWORK: 'OP Rollup 901'
         ETHEREUM_JSONRPC_VARIANT: 'geth'
         ETHEREUM_JSONRPC_HTTP_URL: http://op1-l2:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://op1-l2:8545/
@@ -460,6 +461,7 @@ services:
     env_file:
       - ../blockscout/docker-compose/envs/common-blockscout.env
     environment:
+        SUBNETWORK: 'OP Rollup 902'
         ETHEREUM_JSONRPC_VARIANT: 'geth'
         ETHEREUM_JSONRPC_HTTP_URL: http://op2-l2:8545/
         ETHEREUM_JSONRPC_TRACE_URL: http://op2-l2:8545/

--- a/ops-bedrock/docker-compose.yml
+++ b/ops-bedrock/docker-compose.yml
@@ -251,6 +251,7 @@ services:
         ECTO_USE_SSL: 'false'
         SECRET_KEY_BASE: '56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN'
         MIX_ENV: 'prod'
+        INDEXER_CATCHUP_BLOCK_INTERVAL: '1s'
     ports:
       - "$OP1_BLOCKSCOUT_PORT:4000"
     volumes:
@@ -473,6 +474,7 @@ services:
         ECTO_USE_SSL: 'false'
         SECRET_KEY_BASE: '56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN'
         MIX_ENV: 'prod'
+        INDEXER_CATCHUP_BLOCK_INTERVAL: '1s'
     ports:
       - "$OP2_BLOCKSCOUT_PORT:4000"
     volumes:

--- a/packages/contracts-bedrock/deploy-config/devnetL1-espresso.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-espresso.json
@@ -41,7 +41,7 @@
   "governanceTokenOwner": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
   "eip1559Denominator": 50,
   "eip1559Elasticity": 6,
-  "l1GenesisBlockTimestamp": "0x64fcf2bf",
+  "l1GenesisBlockTimestamp": "0x64fcf4d2",
   "l2GenesisRegolithTimeOffset": "0x0",
   "faultGameAbsolutePrestate": "0x41c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,

--- a/packages/contracts-bedrock/deploy-config/devnetL1-espresso.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-espresso.json
@@ -41,7 +41,7 @@
   "governanceTokenOwner": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
   "eip1559Denominator": 50,
   "eip1559Elasticity": 6,
-  "l1GenesisBlockTimestamp": "0x64fcf092",
+  "l1GenesisBlockTimestamp": "0x64fcf2bf",
   "l2GenesisRegolithTimeOffset": "0x0",
   "faultGameAbsolutePrestate": "0x41c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,

--- a/packages/contracts-bedrock/deploy-config/devnetL1-espresso.json
+++ b/packages/contracts-bedrock/deploy-config/devnetL1-espresso.json
@@ -41,7 +41,7 @@
   "governanceTokenOwner": "0xa0Ee7A142d267C1f36714E4a8F75612F20a79720",
   "eip1559Denominator": 50,
   "eip1559Elasticity": 6,
-  "l1GenesisBlockTimestamp": "0x64fa628c",
+  "l1GenesisBlockTimestamp": "0x64fcf092",
   "l2GenesisRegolithTimeOffset": "0x0",
   "faultGameAbsolutePrestate": "0x41c7ae758795765c6664a5d39bf63841c71ff191e9189522bad8ebff5d4eca98",
   "faultGameMaxDepth": 30,


### PR DESCRIPTION
* Set the name of each chain in the block explorer config, so the browser tab for each block explorer now has a unique title with the chain ID of that explorer. Makes it a bit easier to keep track of what you're looking at
* Changed the block explorer polling interval from the default 5s to 1s, so we can visualize the low latency
* Incorporated a change from @sveitser  to make shutdown faster. This is nice for testing/practicing because it makes the loop shorter