### PR TITLE
Fix lint

### DIFF
--- a/packages/sdk/tasks/deploy-erc20.ts
+++ b/packages/sdk/tasks/deploy-erc20.ts
@@ -5,18 +5,10 @@ import 'hardhat-deploy'
 import { Contract, Wallet, providers, utils } from 'ethers'
 import Artifact__WETH9 from '@eth-optimism/contracts-bedrock/forge-artifacts/WETH9.sol/WETH9.json'
 
-import {
-  CrossChainMessenger,
-  MessageStatus,
-  CONTRACT_ADDRESSES,
-  OEContractsLike,
-  DEFAULT_L2_CONTRACT_ADDRESSES,
-} from '../src'
-
 const deployWETH9 = async (
   hre: HardhatRuntimeEnvironment,
   wrap: boolean,
-  signer: Wallet,
+  signer: Wallet
 ): Promise<Contract> => {
   const Factory__WETH9 = new hre.ethers.ContractFactory(
     Artifact__WETH9.abi,
@@ -50,13 +42,13 @@ task('deploy-erc20', 'Deploy WETH9 onto L2.')
   .setAction(async (args, hre) => {
     // Use signer 11, hopefully not used by anything else.
     const wallet = Wallet.fromMnemonic(
-      "test test test test test test test test test test test junk",
+      'test test test test test test test test test test test junk',
       "m/44'/60'/0'/0/10"
-    );
-    console.log("Using deployer wallet address: ", wallet.address)
+    )
+    console.log('Using deployer wallet address: ', wallet.address)
 
     const l2Provider = new providers.StaticJsonRpcProvider(args.l2ProviderUrl)
-    const l2Signer = wallet.connect(l2Provider);
+    const l2Signer = wallet.connect(l2Provider)
 
     console.log('Deploying WETH9 to L2')
     const WETH_L2 = await deployWETH9(hre, true, l2Signer)


### PR DESCRIPTION
Running `pnpm lint` passes now. I think we can skip the CI.