### PR TITLE
Make Espresso devnet test less flaky

### DIFF
--- a/packages/sdk/tasks/deposit-erc20.ts
+++ b/packages/sdk/tasks/deposit-erc20.ts
@@ -252,7 +252,7 @@ task('deposit-erc20', 'Deposits WETH9 onto L2.')
     console.log('Checking to make sure deposit was successful')
     // Deposit might get reorged, wait and also log for reorgs.
     let prevBlockHash: string = ''
-    for (let i = 0; i < 12; i++) {
+    for (let i = 0; i < 18; i++) {
       const messageReceipt = await signer.provider!.getTransactionReceipt(
         depositTx.hash
       )


### PR DESCRIPTION
The deposit-erc20 test waits 12 seconds after depositing before checking the balance. This is 4 L1 blocks, uncomfortably close to the configured L1 conf depth of 3. As a result, the test sometimes fails because the balance hasn't updated after 12 seconds. Add two more L1 block times for safety.